### PR TITLE
Add setAutoLogAppEventsEnabled for GDPR compliance

### DIFF
--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -2,6 +2,7 @@ package id.oddbit.flutter.facebook_app_events
 
 import android.os.Bundle
 import android.util.Log
+import com.facebook.FacebookSdk
 import com.facebook.appevents.AppEventsLogger
 import com.facebook.GraphRequest
 import com.facebook.GraphResponse
@@ -38,6 +39,7 @@ class FacebookAppEventsPlugin(registrar: Registrar) : MethodCallHandler {
       "setUserData" -> handleSetUserData(call, result)
       "setUserID" -> handleSetUserId(call, result)
       "updateUserProperties" -> handleUpdateUserProperties(call, result)
+      "setAutoLogAppEventsEnabled" -> handleSetAutoLogAppEventsEnabled(call, result)
       else -> result.notImplemented()
     }
   }
@@ -172,5 +174,11 @@ class FacebookAppEventsPlugin(registrar: Registrar) : MethodCallHandler {
       }
     }
     return bundle
+  }
+
+  private fun handleSetAutoLogAppEventsEnabled(call: MethodCall, result: Result) {
+    val enabled = call.arguments as Boolean
+    FacebookSdk.setAutoLogAppEventsEnabled(enabled)
+    result.success(null)
   }
 }

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -38,6 +38,9 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         case "updateUserProperties":
             handleUpdateUserProperties(call, result: result)
             break
+        case "setAutoLogAppEventsEnabled":
+            handleSetAutoLogAppEventsEnabled(call, result: result)
+            break
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -122,5 +125,11 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
                 result(response)
             }
         })
+    }
+    
+    private func handleSetAutoLogAppEventsEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let enabled = call.arguments as! Bool
+        Settings.isAutoLogAppEventsEnabled = enabled
+        result(nil)
     }
 }

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -202,4 +202,12 @@ class FacebookAppEvents {
     });
     return filtered;
   }
+
+  /// Re-enables auto logging of app events after user consent
+  /// if disabled for GDPR-compliance.
+  ///
+  /// See: https://developers.facebook.com/docs/app-events/gdpr-compliance
+  Future<void> setAutoLogAppEventsEnabled(bool enabled) {
+    return _channel.invokeMethod<void>('setAutoLogAppEventsEnabled', enabled);
+  }
 }


### PR DESCRIPTION
Needed for GDPR compliance to be able to delay event tracking until after gaining user consent. See https://developers.facebook.com/docs/app-events/gdpr-compliance