### PR TITLE
Issue/127 compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.13.3
+**N.B. Workaround release!!**
+Removing function body for iOS handling of deprecated method `setUserData`. See issues [#127](https://github.com/oddbit/flutter_facebook_app_events/issues/127) and [#129](https://github.com/oddbit/flutter_facebook_app_events/issues/129). We 
+were unable to reproduce or successfully troubleshoot the reported problems within the team and decided that it would be 
+better to get around the compilation error with the sacrifice of the `setUserData` in the possibly short time before it
+is removed from the SDK anyway.
+
 ## 0.13.2
 - Addressing issue [#125](https://github.com/oddbit/flutter_facebook_app_events/issues/125) - iOS compilation error. See [PR #126](https://github.com/oddbit/flutter_facebook_app_events/pull/126)
 

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -114,19 +114,13 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
 
-    private func handleSetUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        let arguments = call.arguments as? [String: Any] ?? [String: Any]()
-        AppEvents.setUserData(arguments["email"] as? String, forType: FBSDKAppEventUserDataType.email)
-        AppEvents.setUserData(arguments["firstName"] as? String, forType: FBSDKAppEventUserDataType.firstName)
-        AppEvents.setUserData(arguments["lastName"] as? String, forType: FBSDKAppEventUserDataType.lastName)
-        AppEvents.setUserData(arguments["phone"] as? String, forType: FBSDKAppEventUserDataType.phone)
-        AppEvents.setUserData(arguments["dateOfBirth"] as? String, forType: FBSDKAppEventUserDataType.dateOfBirth)
-        AppEvents.setUserData(arguments["gender"] as? String, forType: FBSDKAppEventUserDataType.gender)
-        AppEvents.setUserData(arguments["city"] as? String, forType: FBSDKAppEventUserDataType.city)
-        AppEvents.setUserData(arguments["state"] as? String, forType: FBSDKAppEventUserDataType.state)
-        AppEvents.setUserData(arguments["zip"] as? String, forType: FBSDKAppEventUserDataType.zip)
-        AppEvents.setUserData(arguments["country"] as? String, forType: FBSDKAppEventUserDataType.country)
-
+    private func handleSetUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {        
+        // Function body removed to work around issues reported in #127 and #129 that we couldn't find
+        // a workaround for. This function will be removed in Facebook SDK release v12 and we'll 
+        // have a non-workign deprecated function until then.
+        //  - iOS removal note: https://github.com/facebook/facebook-ios-sdk/blob/0e1d8774db783d85bd8fc3b53ec96444c048ae42/CHANGELOG.md#removed
+        //  - Android deprecation: https://github.com/facebook/facebook-android-sdk/blob/9da80baea0d23a82ce797e17bd4bc0e0d75b3912/facebook-core/src/main/java/com/facebook/appevents/AppEventsLogger.kt#L633 
+        // Leave this one here for until fully removed in SDK v12
         result(nil)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.13.2
+version: 0.13.3
 homepage: https://github.com/oddbit/flutter_facebook_app_events
 
 environment:


### PR DESCRIPTION
Removing function body for iOS handling of deprecated method `setUserData`. See issues [#127](https://github.com/oddbit/flutter_facebook_app_events/issues/127) and [#129](https://github.com/oddbit/flutter_facebook_app_events/issues/129). We 
were unable to reproduce or successfully troubleshoot the reported problems within the team and decided that it would be 
better to get around the compilation error with the sacrifice of the `setUserData` in the possibly short time before it
is removed from the SDK anyway.

- Closes #127 
- Closes #129