### PR TITLE
IOS compilation error with version 14 x x

### DIFF
--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -86,7 +86,7 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
     private func handleLogEvent(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? [String: Any] ?? [String: Any]()
         let eventName = arguments["name"] as! String
-        let parameters = arguments["parameters"] as? [AppEvents.ParameterName.RawValue: Any] ?? [AppEvents.ParameterName.RawValue: Any]()
+        let parameters = arguments["parameters"] as? [AppEvents.ParameterName: Any] ?? [AppEvents.ParameterName: Any]()
         if arguments["_valueToSum"] != nil && !(arguments["_valueToSum"] is NSNull) {
             let valueToDouble = arguments["_valueToSum"] as! Double
             AppEvents.logEvent(AppEvents.Name(eventName), valueToSum: valueToDouble, parameters: parameters)

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -13,9 +13,9 @@ Flutter plugin for Facebook Analytics and App Events
   s.public_header_files = 'Classes/**/*.h'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 12.0'
+  s.dependency 'FBSDKCoreKit', '~> 12.1.0'
   s.dependency 'FBAudienceNetwork', '~> 6.9.0'
   s.swift_version       = '5.0'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
 end


### PR DESCRIPTION
AppEvents.ParameterName.RawValue works on 12.0.2, so those who get version 12.0.0 when pod install will get an error. 
Close #159 
Close #171 
