### PR TITLE
Specify latest facebook-android-sdk version to fix build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.facebook.android:facebook-android-sdk:12.+'
+    implementation 'com.facebook.android:facebook-android-sdk:12.3.0'
 }


### PR DESCRIPTION
This PR aims to resolve the error in issue https://github.com/oddbit/flutter_facebook_app_events/issues/200

The PR is also related to the discussion in PR https://github.com/oddbit/flutter_facebook_app_events/pull/189

Thanks a lot for the package and the great work you are doing!