### PR TITLE
Adding set user data

### DIFF
--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -42,6 +42,7 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
   override fun onMethodCall(call: MethodCall, result: Result) {
     when (call.method) {
       "clearUserData" -> handleClearUserData(call, result)
+      "setUserData" -> handleSetUserData(call, result)
       "clearUserID" -> handleClearUserId(call, result)
       "flush" -> handleFlush(call, result)
       "getApplicationId" -> handleGetApplicationId(call, result)
@@ -60,6 +61,26 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
 
   private fun handleClearUserData(call: MethodCall, result: Result) {
     AppEventsLogger.clearUserData()
+    result.success(null)
+  }
+
+ private fun handleSetUserData(call: MethodCall, result: Result) {
+    val parameters = call.argument("parameters") as? Map<String, Object>
+    val parameterBundle = createBundleFromMap(parameters)
+
+    AppEventsLogger.setUserData(
+      parameterBundle?.getString("email"),
+      parameterBundle?.getString("firstName"),
+      parameterBundle?.getString("lastName"),
+      parameterBundle?.getString("phone"),
+      parameterBundle?.getString("dateOfBirth"),
+      parameterBundle?.getString("gender"),
+      parameterBundle?.getString("city"),
+      parameterBundle?.getString("state"),
+      parameterBundle?.getString("zip"),
+      parameterBundle?.getString("country")
+    )
+
     result.success(null)
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,18 @@ class MyApp extends StatelessWidget {
                 },
               ),
               MaterialButton(
+                child: Text("Set user data"),
+                onPressed: () {
+                  facebookAppEvents.setUserData(
+                    email: 'opensource@oddbit.id',
+                    firstName: 'Oddbit',
+                    dateOfBirth: '2019-10-19',
+                    city: 'Denpasar',
+                    country: 'Indonesia',
+                  );
+                },
+              ),
+              MaterialButton(
                 child: Text("Test logAddToCart"),
                 onPressed: () {
                   facebookAppEvents.logAddToCart(

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -22,6 +22,9 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         case "clearUserData":
             handleClearUserData(call, result: result)
             break
+        case "setUserData":
+            handleSetUserData(call, result: result)
+            break
         case "clearUserID":
             handleClearUserID(call, result: result)
             break
@@ -62,6 +65,23 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
 
     private func handleClearUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         AppEvents.clearUserData()
+        result(nil)
+    }
+
+    private func handleSetUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {        
+        let arguments = call.arguments as? [String: Any] ?? [String: Any]()
+
+        AppEvents.setUserData(arguments["email"] as? String, forType: FBSDKAppEventUserDataType.email)
+        AppEvents.setUserData(arguments["firstName"] as? String, forType: FBSDKAppEventUserDataType.firstName)
+        AppEvents.setUserData(arguments["lastName"] as? String, forType: FBSDKAppEventUserDataType.lastName)
+        AppEvents.setUserData(arguments["phone"] as? String, forType: FBSDKAppEventUserDataType.phone)
+        AppEvents.setUserData(arguments["dateOfBirth"] as? String, forType: FBSDKAppEventUserDataType.dateOfBirth)
+        AppEvents.setUserData(arguments["gender"] as? String, forType: FBSDKAppEventUserDataType.gender)
+        AppEvents.setUserData(arguments["city"] as? String, forType: FBSDKAppEventUserDataType.city)
+        AppEvents.setUserData(arguments["state"] as? String, forType: FBSDKAppEventUserDataType.state)
+        AppEvents.setUserData(arguments["zip"] as? String, forType: FBSDKAppEventUserDataType.zip)
+        AppEvents.setUserData(arguments["country"] as? String, forType: FBSDKAppEventUserDataType.country)
+
         result(nil)
     }
 

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -50,6 +50,38 @@ class FacebookAppEvents {
     return _channel.invokeMethod<void>('clearUserData');
   }
 
+  /// Sets user data to associate with all app events.
+  /// All user data are hashed and used to match Facebook user from this
+  /// instance of an application. The user data will be persisted between
+  /// application instances.
+  Future<void> setUserData({
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? phone,
+    String? dateOfBirth,
+    String? gender,
+    String? city,
+    String? state,
+    String? zip,
+    String? country,
+  }) {
+    final args = <String, dynamic>{
+      'email': email,
+      'firstName': firstName,
+      'lastName': lastName,
+      'phone': phone,
+      'dateOfBirth': dateOfBirth,
+      'gender': gender,
+      'city': city,
+      'state': state,
+      'zip': zip,
+      'country': country,
+    };
+
+    return _channel.invokeMethod<void>('setUserData', args);
+  }
+
   /// Clears the currently set user id.
   Future<void> clearUserID() {
     return _channel.invokeMethod<void>('clearUserID');


### PR DESCRIPTION
Adding back `setUserData` that was accidentally removed as `deprecated` in [`v0.14.1](https://pub.dev/packages/facebook_app_events/changelog#0141) when it should actually just have been one method signature that was being deprecated.

The deprecation note was only regarding `setUserData(userData: Bundle?)`

https://github.com/facebook/facebook-android-sdk/blob/9da80baea0d23a82ce797e17bd4bc0e0d75b3912/facebook-core/src/main/java/com/facebook/appevents/AppEventsLogger.kt#L577-L583

This PR adds back support for `setUserData()`

