### PR TITLE
Fixed version mismatch with flutter_facebook_auth

### DIFF
--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -13,7 +13,7 @@ Flutter plugin for Facebook Analytics and App Events
   s.public_header_files = 'Classes/**/*.h'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 12.2.1'
+  s.dependency 'FBSDKCoreKit', '~> 12.3.1'
   s.dependency 'FBAudienceNetwork', '~> 6.9.0'
   s.swift_version       = '5.0'
 


### PR DESCRIPTION
There is currently a mismatch on flutter_facebook_auth and flutter_facebook_app_events, because of the fb core cocoapod version.
I have just updated it here to make it work again. :)