### PR TITLE
Expose setApplicationId through the Flutter plugin

### DIFF
--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -41,7 +41,21 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(null)
   }
 
+  val isInitialised: Boolean
+    get() {
+       return appEventsLogger?.applicationId !== null
+    }
+
   override fun onMethodCall(call: MethodCall, result: Result) {
+    if (!isInitialised && !listOf("setApplicationId", "getApplicationId").contains(call.method)) {
+        result.error(
+            "FB_APP_ID_NOT_SET",
+            "Cannot call method " + call.method + " before setApplicationId",
+            "You need to initialise the SDK with a valid Facebook Application Id. Use the setApplicationId SDK method."
+        )
+        return
+    }
+
     when (call.method) {
       "setApplicationId" -> handleSetApplicationId(call, result)
       "clearUserData" -> handleClearUserData(call, result)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,8 +3,14 @@ import 'package:facebook_app_events/facebook_app_events.dart';
 
 void main() => runApp(MyApp());
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
   static final facebookAppEvents = FacebookAppEvents();
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -16,6 +22,37 @@ class MyApp extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              MaterialButton(
+                child: Text("Set Application Id = null"),
+                onPressed: () async {
+                  await facebookAppEvents.setApplicationId(null);
+                  setState(() => {});
+                },
+              ),
+              MaterialButton(
+                child: Text("Set Application Id = a"),
+                onPressed: () async {
+                  await facebookAppEvents.setApplicationId("a");
+                  setState(() => {});
+                },
+              ),
+              MaterialButton(
+                child: Text("Set Application Id = b"),
+                onPressed: () async {
+                  await facebookAppEvents.setApplicationId("b");
+                  setState(() => {});
+                },
+              ),
+              FutureBuilder(
+                future: facebookAppEvents.getApplicationId(),
+                builder: (context, snapshot) {
+                  final id = snapshot.data ?? '???';
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16.0),
+                    child: Text('Application ID: $id'),
+                  );
+                },
+              ),
               FutureBuilder(
                 future: facebookAppEvents.getAnonymousId(),
                 builder: (context, snapshot) {
@@ -60,7 +97,8 @@ class MyApp extends StatelessWidget {
               MaterialButton(
                 child: Text("Test purchase!"),
                 onPressed: () {
-                  facebookAppEvents.logPurchase(amount: 1, currency: "USD");
+                  facebookAppEvents
+                      .logPurchase(amount: 1, currency: "USD");
                 },
               ),
               MaterialButton(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,11 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   static final facebookAppEvents = FacebookAppEvents();
+  String _error;
+
+  _handleError(dynamic err, StackTrace stack) {
+    print("error catched: $err $stack");
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,21 +30,27 @@ class _MyAppState extends State<MyApp> {
               MaterialButton(
                 child: Text("Set Application Id = null"),
                 onPressed: () async {
-                  await facebookAppEvents.setApplicationId(null);
+                  await facebookAppEvents
+                      .setApplicationId(null)
+                      .catchError(_handleError);
                   setState(() => {});
                 },
               ),
               MaterialButton(
                 child: Text("Set Application Id = a"),
                 onPressed: () async {
-                  await facebookAppEvents.setApplicationId("a");
+                  await facebookAppEvents
+                      .setApplicationId("a")
+                      .catchError(_handleError);
                   setState(() => {});
                 },
               ),
               MaterialButton(
                 child: Text("Set Application Id = b"),
                 onPressed: () async {
-                  await facebookAppEvents.setApplicationId("b");
+                  await facebookAppEvents
+                      .setApplicationId("b")
+                      .catchError(_handleError);
                   setState(() => {});
                 },
               ),
@@ -47,6 +58,11 @@ class _MyAppState extends State<MyApp> {
                 future: facebookAppEvents.getApplicationId(),
                 builder: (context, snapshot) {
                   final id = snapshot.data ?? '???';
+
+                  if (snapshot.hasError) {
+                    _handleError(snapshot.error, snapshot.stackTrace);
+                  }
+
                   return Padding(
                     padding: const EdgeInsets.symmetric(vertical: 16.0),
                     child: Text('Application ID: $id'),
@@ -57,6 +73,11 @@ class _MyAppState extends State<MyApp> {
                 future: facebookAppEvents.getAnonymousId(),
                 builder: (context, snapshot) {
                   final id = snapshot.data ?? '???';
+
+                  if (snapshot.hasError) {
+                    _handleError(snapshot.error, snapshot.stackTrace);
+                  }
+
                   return Text('Anonymous ID: $id');
                 },
               ),
@@ -68,49 +89,58 @@ class _MyAppState extends State<MyApp> {
                     parameters: {
                       'button_id': 'the_clickme_button',
                     },
-                  );
+                  ).catchError(_handleError);
                 },
               ),
               MaterialButton(
                 child: Text("Set user data"),
                 onPressed: () {
-                  facebookAppEvents.setUserData(
-                    email: 'opensource@oddbit.id',
-                    firstName: 'Oddbit',
-                    dateOfBirth: '2019-10-19',
-                    city: 'Denpasar',
-                    country: 'Indonesia',
-                  );
+                  facebookAppEvents
+                      .setUserData(
+                        email: 'opensource@oddbit.id',
+                        firstName: 'Oddbit',
+                        dateOfBirth: '2019-10-19',
+                        city: 'Denpasar',
+                        country: 'Indonesia',
+                      )
+                      .catchError(_handleError);
                 },
               ),
               MaterialButton(
                 child: Text("Test logAddToCart"),
                 onPressed: () {
-                  facebookAppEvents.logAddToCart(
-                    id: '1',
-                    type: 'product',
-                    price: 99.0,
-                    currency: 'TRY',
-                  );
+                  facebookAppEvents
+                      .logAddToCart(
+                        id: '1',
+                        type: 'product',
+                        price: 99.0,
+                        currency: 'TRY',
+                      )
+                      .catchError(_handleError);
                 },
               ),
               MaterialButton(
                 child: Text("Test purchase!"),
                 onPressed: () {
                   facebookAppEvents
-                      .logPurchase(amount: 1, currency: "USD");
+                      .logPurchase(amount: 1, currency: "USD")
+                      .catchError(_handleError);
                 },
               ),
               MaterialButton(
                 child: Text("Enable advertise tracking!"),
                 onPressed: () {
-                  facebookAppEvents.setAdvertiserTracking(enabled: true);
+                  facebookAppEvents
+                      .setAdvertiserTracking(enabled: true)
+                      .catchError(_handleError);
                 },
               ),
               MaterialButton(
                 child: Text("Disabled advertise tracking!"),
                 onPressed: () {
-                  facebookAppEvents.setAdvertiserTracking(enabled: false);
+                  facebookAppEvents
+                      .setAdvertiserTracking(enabled: false)
+                      .catchError(_handleError);
                 },
               ),
             ],

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -17,6 +17,17 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if (Settings.shared.appID == nil && !["setApplicationId", "getApplicationId"].contains(call.method)) {
+            result(
+                FlutterError(
+                    code: "FB_APP_ID_NOT_SET", 
+                    message: "Cannot call method \(call.method) before setApplicationId",
+                    details: "You need to initialise the SDK with a valid Facebook Application Id. Use the setApplicationId SDK method."
+                )
+            )
+            return
+        }
+
         switch call.method {
         case "setApplicationId":
             handleSetApplicationId(call, result: result)

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -13,12 +13,14 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         // See: https://developers.facebook.com/blog/post/2021/01/19/introducing-facebook-platform-sdk-version-9/
         // "Removal of Auto Initialization of SDK" section
         ApplicationDelegate.shared.initializeSDK()
-
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
+        case "setApplicationId":
+            handleSetApplicationId(call, result: result)
+            break
         case "clearUserData":
             handleClearUserData(call, result: result)
             break
@@ -61,6 +63,30 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func handleSetApplicationId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let newApplicationId = call.arguments as? String
+
+        if (newApplicationId?.compare(Settings.shared.appID ?? "", options: .literal) == .orderedSame) {
+            print("facebook_app_events :: setApplicationId :: application id didn't change, nothing to do here")
+            result(nil)
+            return
+        }
+        
+        AppEvents.shared.flush()
+        
+        if (newApplicationId == nil) {
+            print("facebook_app_events :: setApplicationId :: applicationId = null")
+            Settings.shared.appID = nil
+            result(nil)
+            return
+        }
+        
+        // initialize a new logger with the requested application id
+        print("facebook_app_events :: setApplicationId :: applicationId = \(newApplicationId!)")
+        Settings.shared.appID = newApplicationId
+        result(nil)
     }
 
     private func handleClearUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -92,13 +92,18 @@ class FacebookAppEvents {
     return _channel.invokeMethod<void>('flush');
   }
 
+  /// Set the app ID.
+  Future<void> setApplicationId(String? applicationId) {
+    return _channel.invokeMethod<String?>('setApplicationId', applicationId);
+  }
+
   /// Returns the app ID this logger was configured to log to.
   Future<String?> getApplicationId() {
-    return _channel.invokeMethod<String>('getApplicationId');
+    return _channel.invokeMethod<String?>('getApplicationId');
   }
 
   Future<String?> getAnonymousId() {
-    return _channel.invokeMethod<String>('getAnonymousId');
+    return _channel.invokeMethod<String?>('getAnonymousId');
   }
 
   /// Log an app event with the specified [name] and the supplied [parameters] value.


### PR DESCRIPTION
This change is expose a new `setApplicationId` method through the flutter bridge in order to be able to dynamically set the Facebook `applicationId`