### PR TITLE
added connection of AppDelegate & sdk

### DIFF
--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -15,6 +15,26 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         ApplicationDelegate.shared.initializeSDK()
 
         registrar.addMethodCallDelegate(instance, channel: channel)
+        registrar.addApplicationDelegate(instance)
+    }
+    
+    /// Connect app delegate with SDK
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
+        var options = [UIApplication.LaunchOptionsKey: Any]()
+        for (k, value) in launchOptions {
+            let key = k as! UIApplication.LaunchOptionsKey
+            options[key] = value
+        }
+        ApplicationDelegate.shared.application(application,didFinishLaunchingWithOptions: options)
+        return true
+    }
+    
+    public func application( _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
+        let processed = ApplicationDelegate.shared.application(
+            app, open: url,
+            sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
+            annotation: options[UIApplication.OpenURLOptionsKey.annotation])
+        return processed;
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {


### PR DESCRIPTION
This might be a "controversial change", but I've encountered an issue on my end, maybe someone else encountered something similar. 

In "Facebook Events Manager" for my project, I needed to "configure app Events for SKAdNetwork" on iOS side of things. 

<img width="640" alt="image" src="https://user-images.githubusercontent.com/5318653/169561744-997768c3-7544-4ffc-917a-93c5fb32ff20.png">

Before you can do it, you have to go through verification procedure, where they send you a notification to a facebook app on your phone, which then opens up you app.

When running this verification, it kept failing, right until a moment I've introduced changes suggested in this PR. 

Maybe my solution was just a fluke, but it helped me, so I've decided to submit it for review, just in case somebody else encounters something similar. 
 