### PR TITLE
Issue/264 fbsdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.1
+- Fixing version syntax in gradle.
+
 ## 0.18.0
 - Updating Facebook SDK  dependency to follow all `15.x` versions.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,15 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.facebook.android:facebook-android-sdk:15.+'
+    // # READ THIS
+    // When updating the Facebook SDK. Please note these guidelines to avoid
+    // conflicts with other plugins that also rely on the FBSDK.
+    //
+    // - Only specify the major version of the SDK. 
+    // - Do **not** specify the `minor` or `patch` version.
+    //
+    // About the version syntax:
+    //  - https://github.com/oddbit/flutter_facebook_app_events/pull/189#discussion_r768267841
+    //  - https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402
+    implementation 'com.facebook.android:facebook-android-sdk:[15.0,16.0)'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.18.0
+version: 0.18.1
 homepage: https://github.com/oddbit/flutter_facebook_app_events
 
 environment:


### PR DESCRIPTION
Fixing FBSDK version syntax on Android Gradle (closes #264).

The fix for this issue is related to a previous conversation in another PR https://github.com/oddbit/flutter_facebook_app_events/pull/189#discussion_r768267841