### PR TITLE
add `FBAdSettings.setAdvertiserTrackingEnabled`

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - facebook_app_events (0.0.1):
-    - FBAudienceNetwork (~> 6.9.0)
-    - FBSDKCoreKit (~> 15.0)
+    - FBAudienceNetwork (~> 6.12)
+    - FBSDKCoreKit (~> 15.1)
     - Flutter
   - FBAEMKit (15.1.0):
     - FBSDKCoreKit_Basics (= 15.1.0)
-  - FBAudienceNetwork (6.9.0)
+  - FBAudienceNetwork (6.12.0)
   - FBSDKCoreKit (15.1.0):
     - FBAEMKit (= 15.1.0)
     - FBSDKCoreKit_Basics (= 15.1.0)
@@ -30,9 +30,9 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  facebook_app_events: 50f806e9b8bd2d2743563c6c541eba83dfbfadcc
+  facebook_app_events: 1b116476dfbe0fbb66cb21419cf9a6f30b391057
   FBAEMKit: c7f82b5145d446bcbbcd50485c032689032fc6a2
-  FBAudienceNetwork: 83096d73433759c10f9cf9b3bad5e5cff58694cb
+  FBAudienceNetwork: e0fcc9091fced34910ed0b6da06f129db46ac9e6
   FBSDKCoreKit: 7542746fc63a2a38dd6a865eeb54268341f37b83
   FBSDKCoreKit_Basics: 92d6b26c0bed30ab09bbdd96dccaa26e6c9978d1
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.1"
+    version: "0.18.2"
   fake_async:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -187,6 +187,7 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
         let arguments = call.arguments as? [String: Any] ?? [String: Any]()
         let enabled = arguments["enabled"] as! Bool
         let collectId = arguments["collectId"] as! Bool
+        FBAdSettings.setAdvertiserTrackingEnabled(enabled)
         Settings.shared.isAdvertiserTrackingEnabled = enabled
         Settings.shared.isAdvertiserIDCollectionEnabled = collectId
         result(nil)

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -18,9 +18,9 @@ Flutter plugin for Facebook Analytics and App Events
 
   # Do not specify PATCH version of FBSDKCoreKit. See README file for explanation
   # https://github.com/oddbit/flutter_facebook_app_events#dependencies-on-facebook-sdk
-  s.dependency 'FBSDKCoreKit', '~> 15.0'
+  s.dependency 'FBSDKCoreKit', '~> 15.1'
   
   # See docs on FBAudienceNetwork
   # https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk/
-  s.dependency 'FBAudienceNetwork', '~> 6.9'
+  s.dependency 'FBAudienceNetwork', '~> 6.12'
 end


### PR DESCRIPTION
- upgrade `FBSDKCoreKit` to v15.1
- upgrade `FBAudienceNetwork` to v6.12
- add `FBAdSettings.setAdvertiserTrackingEnabled` within `handleSetAdvertiserTracking` method for iOS platform.

<img width="348" alt="image" src="https://user-images.githubusercontent.com/11278416/204052365-7d5fcd79-5b83-4345-83af-2be5892d061a.png">

[https://developers.facebook.com/docs/app-events/guides/advertising-tracking-enabled/](https://developers.facebook.com/docs/app-events/guides/advertising-tracking-enabled/)
