### PR TITLE
Typo: Change `tutuorial` to `tutorial`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After that, add that string resource reference to your main `AndroidManifest.xml
 
 ### Configure iOS
 
-Read through the "[Getting Started with App Events for iOS](https://developers.facebook.com/docs/app-events/getting-started-app-events-ios)" tutuorial and in particular, follow [step 5](https://developers.facebook.com/docs/app-events/getting-started-app-events-ios#step-5--configure-your-project) by opening `info.plist` "As Source Code" and add the following
+Read through the "[Getting Started with App Events for iOS](https://developers.facebook.com/docs/app-events/getting-started-app-events-ios)" tutorial and in particular, follow [step 5](https://developers.facebook.com/docs/app-events/getting-started-app-events-ios#step-5--configure-your-project) by opening `info.plist` "As Source Code" and add the following
 
 - If your code does not have `CFBundleURLTypes`, add the following just before the final `</dict>` element:
 


### PR DESCRIPTION
### What?
This PR fixes the typo `tutuorial` to `tutorial`.