### PR TITLE
🐛 fix: include namespace information

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'id.oddbit.flutter.facebook_app_events'
     compileSdkVersion 28
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'id.oddbit.flutter.facebook_app_events_example'
     compileSdkVersion 31
 
     sourceSets {


### PR DESCRIPTION
Fixes:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':facebook_app_events'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }

     If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```