### PR TITLE
Removes references to Flutter v1 Android embedding classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.19.5
+- Removes references to Flutter v1 android embedding classes.
+
 ## 0.19.4
 - Updating `FBAudienceNetwork`to version `6.16`
 - Updating iOS properties

--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.util.Currency
 
 /** FacebookAppEventsPlugin */

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.19.4
+version: 0.19.5
 homepage: https://github.com/oddbit/flutter_facebook_app_events
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/oddbit/flutter_facebook_app_events/issues/373 (does not appear this issue should have been closed, but I cannot reopen it).

Tested by building the flutter_facebook_app_events example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 
