### PR TITLE
docs: Added missing fb_login_protocol_scheme and app_name values to README for android configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Read through the "[Getting Started with App Events for Android](https://develope
 <resources>
   <string name="facebook_app_id">[APP_ID]</string>
   <string name="facebook_client_token">[CLIENT_TOKEN]</string>
+  <string name="fb_login_protocol_scheme">fb[APP_ID]</string>
+  <string name="app_name">[APP_NAME]</string>
 </resources>
 ```
 


### PR DESCRIPTION
I realized that the android configuration has missing some values in styles.xml file so I want to fix it.

Especially if you don't add  `<string name="app_name">[APP_NAME]</string>` line, you face to an error about AndroidManifest.xml file syntax error or like this.

