### PR TITLE
fix: downgrade FBAudienceNetwork dependency version 6.14 in facebook_app_events.podspec

### DIFF
--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -22,5 +22,5 @@ Flutter plugin for Facebook Analytics and App Events
   
   # See docs on FBAudienceNetwork
   # https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk/
-  s.dependency 'FBAudienceNetwork', '6.16'
+  s.dependency 'FBAudienceNetwork', '6.14'
 end


### PR DESCRIPTION
Initially, please clear the pub cache for this package located at `~/.pub-cache/hosted/pub.dev/facebook_app_events-XXX`, as the build encounters failures during a fresh installation.

https://github.com/oddbit/flutter_facebook_app_events/issues/368#issuecomment-2242864616
