### PR TITLE
Remove flutter android v1 embedding

### DIFF
--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.util.Currency
 
 /** FacebookAppEventsPlugin */


### PR DESCRIPTION
In the upcoming flutter release the android v1 embedding will be removed. Therefore, the current beta branch is not compatible with this package.

This probably requires a major new version to signal the breaking change. Happy about any feedback