### PR TITLE
Upgrade to Facebook SDK v21.0.0 (v0.20.0 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.0
+- Upgrade Facebook SDK to v21.0.0
+  - Updated iOS FBSDKCoreKit to 21.0.0
+  - Updated Android Facebook Core SDK to 21.0.0
+
 ## 0.19.7
 - Update iOS `FBSDKCoreKit` to `18.0`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,6 +61,6 @@ android {
         // About the version syntax:
         //  - https://github.com/oddbit/flutter_facebook_app_events/pull/189#discussion_r768267841
         //  - https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402
-        implementation("com.facebook.android:facebook-android-sdk:[17.0,18.0)")
+        implementation("com.facebook.android:facebook-android-sdk:[21.0,22.0)")
     }
 }

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -18,7 +18,7 @@ Flutter plugin for Facebook Analytics and App Events
 
   # Do not specify PATCH version of FBSDKCoreKit. See README file for explanation
   # https://github.com/oddbit/flutter_facebook_app_events#dependencies-on-facebook-sdk
-  s.dependency 'FBSDKCoreKit', '~> 18.0'
+  s.dependency 'FBSDKCoreKit', '~> 21.0'
   
   # See docs on FBAudienceNetwork
   # https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.19.7
+version: 0.20.0
 homepage: https://github.com/oddbit/flutter_facebook_app_events
 
 environment:


### PR DESCRIPTION
Update facebook_app_events plugin to version 0.20.0 and upgrade Facebook SDKs to 21.0.0.

* **pubspec.yaml**
  - Update version to 0.20.0

* **ios/facebook_app_events.podspec**
  - Update FBSDKCoreKit dependency to version 21.0.0

* **android/build.gradle**
  - Update Facebook Android SDK dependency to version 21.0.0

* **CHANGELOG.md**
  - Add entry for version 0.20.0 with details of the updates
  - Move the changelog description for 0.20.0 to the top of the file
