### PR TITLE
fix: Update iOS Swift code for Facebook SDK 18.x compatibility

### DIFF
--- a/ios/Classes/SwiftFacebookAppEventsPlugin.swift
+++ b/ios/Classes/SwiftFacebookAppEventsPlugin.swift
@@ -18,12 +18,6 @@ public class SwiftFacebookAppEventsPlugin: NSObject, FlutterPlugin {
     }
     
     /// Connect app delegate with SDK
-    /// Note: For Facebook SDK 18.x+, didFinishLaunchingWithOptions is handled via initializeSDK()
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
-        // SDK initialization is already handled in register() via initializeSDK()
-        return true
-    }
-    
     public func application( _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
         // For Facebook SDK 18.x+, use the simplified URL handling
         return ApplicationDelegate.shared.application(app, open: url, options: options)


### PR DESCRIPTION
## Summary
Updates the iOS Swift plugin code to be compatible with Facebook SDK 18.x.

## Changes
- Updated `ApplicationDelegate` URL handling for SDK 18.x API
- Fixed `getApplicationId` to read from Info.plist (SDK 18.x removed `Settings.appID`)
- Added deprecation warning for `setDataProcessingOptions` (removed in SDK 18.x)
- Removed duplicate `isAdvertiserTrackingEnabled` assignment
- Simplified `didFinishLaunchingWithOptions` (SDK init handled via `initializeSDK()`)

## Breaking Changes
- `setDataProcessingOptions()` - This method is no longer available in Facebook SDK 18.x. For CCPA compliance, configure data processing options via Facebook's Data Use Checkup in your app's Facebook Developer settings. The method now logs a warning and returns successfully.

## Testing
- Verified iOS simulator build compiles successfully
- Tested with Flutter 3.35.0 and Facebook SDK 18.0.2