### PR TITLE
Added activateApp method

### DIFF
--- a/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
+++ b/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
@@ -32,6 +32,8 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin {
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
+        case "activateApp":
+            handleActivateApp(call, result: result)
         case "clearUserData":
             handleClearUserData(call, result: result)
         case "setUserData":
@@ -61,6 +63,11 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin {
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func handleActivateApp(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        AppEvents.shared.activateApp()
+        result(nil)
     }
 
     private func handleClearUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -45,6 +45,26 @@ class FacebookAppEvents {
   /// This could be an EAN, article identifier, etc., depending on the nature of the app.
   static const paramNameContentId = "fb_content_id";
 
+  /// Notifies the events system that the app has launched.
+  /// Activation and deactivation events will then be logged automatically.
+  /// This is normally called during SDK initialization.
+  ///
+  /// If `FacebookAutoLogAppEventsEnabled` (iOS) or
+  /// `com.facebook.sdk.AutoLogAppEventsEnabled` (Android) is set to `false`,
+  /// call this method to log activation and install events manually.
+  ///
+  /// Android only: Providing an [applicationId] overrides the application ID
+  /// used to initialize the SDK.
+  Future<void> activateApp({String? applicationId}) {
+    final args = <String, dynamic>{};
+
+    if (applicationId != null) {
+      args['applicationId'] = applicationId;
+    }
+
+    return _channel.invokeMethod<void>('activateApp', args);
+  }
+
   /// Clears the current user data
   Future<void> clearUserData() {
     return _channel.invokeMethod<void>('clearUserData');


### PR DESCRIPTION
These changes add activateApp method that is needed for manual activation of FB sdk while using setAutoLogAppEventsEnabled(false) for some of the subscription sdk packages.