### PR TITLE
fix: move swift-tools-version to first line of Package.swift

### DIFF
--- a/ios/facebook_app_events/Package.swift
+++ b/ios/facebook_app_events/Package.swift
@@ -1,9 +1,9 @@
+// swift-tools-version: 5.9
 // Copyright (c) Oddbit (https://oddbit.id)
 //
 // This source file is part of facebook_app_events.
 // Licensed under the Apache License, Version 2.0. See LICENSE and NOTICE.
 
-// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Swift 6.0+ requires the `swift-tools-version` declaration to be on the very first 
line of `Package.swift`. The current file has a copyright header before it, which 
causes Xcode (Swift 6.0+) to fail with:

> the manifest is backward-incompatible with Swift < 6.0 because the tools-version 
> was specified in a subsequent line of the manifest, not the first line.

This moves the `// swift-tools-version: 5.9` comment to line 1, before the copyright 
header, following the Swift Package Manager specification.