### PR TITLE
feat: add custom parameters support to standard events and document ROAS pattern

### DIFF
--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -518,7 +518,7 @@ class FacebookAppEvents {
   /// Log this event when the user views an ad.
   ///
   /// To track ad revenue for ROAS optimization, use [logEvent] directly with
-  /// [eventNameAdImpression], passing [valueToSum] (the ad revenue amount) and
+  /// [eventNameAdImpression], passing `valueToSum` (the ad revenue amount) and
   /// [paramNameCurrency] in the parameters map:
   ///
   /// ```dart
@@ -549,7 +549,7 @@ class FacebookAppEvents {
   /// Log this event when the user clicks an ad.
   ///
   /// To track ad revenue for ROAS optimization, use [logEvent] directly with
-  /// [eventNameAdClick], passing [valueToSum] (the ad revenue amount) and
+  /// [eventNameAdClick], passing `valueToSum` (the ad revenue amount) and
   /// [paramNameCurrency] in the parameters map:
   ///
   /// ```dart

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -490,8 +490,9 @@ class FacebookAppEvents {
     double? valueToSum,
     Map<String, dynamic>? parameters,
   }) {
-    assert(valueToSum == null || currency != null,
-        'currency must be provided if valueToSum is provided');
+    if (valueToSum != null && currency == null) {
+      throw ArgumentError('currency must be provided if valueToSum is provided');
+    }
     return logEvent(
       name: eventNameAdImpression,
       parameters: {
@@ -517,8 +518,9 @@ class FacebookAppEvents {
     double? valueToSum,
     Map<String, dynamic>? parameters,
   }) {
-    assert(valueToSum == null || currency != null,
-        'currency must be provided if valueToSum is provided');
+    if (valueToSum != null && currency == null) {
+      throw ArgumentError('currency must be provided if valueToSum is provided');
+    }
     return logEvent(
       name: eventNameAdClick,
       parameters: {

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -241,11 +241,16 @@ class FacebookAppEvents {
   /// See documentation:
   /// - [Standard events](https://developers.facebook.com/docs/app-events/best-practices#standard-events)
   /// - [Android constants](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/appevents/appeventsconstants.html)
-  Future<void> logCompletedRegistration({String? registrationMethod}) {
+  Future<void> logCompletedRegistration({
+    String? registrationMethod,
+    Map<String, dynamic>? parameters,
+  }) {
     return logEvent(
       name: eventNameCompletedRegistration,
       parameters: {
-        paramNameRegistrationMethod: registrationMethod,
+        if (parameters != null) ...parameters,
+        if (registrationMethod != null)
+          paramNameRegistrationMethod: registrationMethod,
       },
     );
   }
@@ -255,14 +260,21 @@ class FacebookAppEvents {
   /// See documentation:
   /// - [Standard events](https://developers.facebook.com/docs/app-events/best-practices#standard-events)
   /// - [Android constants](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/appevents/appeventsconstants.html)
-  Future<void> logRated({double? valueToSum}) {
+  Future<void> logRated({
+    double? valueToSum,
+    Map<String, dynamic>? parameters,
+  }) {
     return logEvent(
       name: eventNameRated,
       valueToSum: valueToSum,
+      parameters: parameters,
     );
   }
 
   /// Log this event when the user has viewed a form of content in the app.
+  ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [price] (as valueToSum) and [currency] parameters.
   ///
   /// See documentation:
   /// - [Standard events](https://developers.facebook.com/docs/app-events/best-practices#standard-events)
@@ -273,20 +285,28 @@ class FacebookAppEvents {
     String? type,
     String? currency,
     double? price,
+    Map<String, dynamic>? parameters,
   }) {
+    if (price != null && currency == null) {
+      throw ArgumentError('currency must be provided if price is provided');
+    }
     return logEvent(
       name: eventNameViewedContent,
       parameters: {
-        paramNameContent: content != null ? json.encode(content) : null,
-        paramNameContentId: id,
-        paramNameContentType: type,
-        paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
+        if (content != null) paramNameContent: json.encode(content),
+        if (id != null) paramNameContentId: id,
+        if (type != null) paramNameContentType: type,
+        if (currency != null) paramNameCurrency: currency,
       },
       valueToSum: price,
     );
   }
 
   /// Log this event when the user has added an item to cart.
+  ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [price] (as valueToSum) and [currency] parameters.
   ///
   /// See documentation:
   /// - [Standard events](https://developers.facebook.com/docs/app-events/best-practices#standard-events)
@@ -297,11 +317,13 @@ class FacebookAppEvents {
     required String type,
     required String currency,
     required double price,
+    Map<String, dynamic>? parameters,
   }) {
     return logEvent(
       name: eventNameAddedToCart,
       parameters: {
-        paramNameContent: content != null ? json.encode(content) : null,
+        if (parameters != null) ...parameters,
+        if (content != null) paramNameContent: json.encode(content),
         paramNameContentId: id,
         paramNameContentType: type,
         paramNameCurrency: currency,
@@ -312,6 +334,9 @@ class FacebookAppEvents {
 
   /// Log this event when the user has added an item to wishlist.
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [price] (as valueToSum) and [currency] parameters.
+  ///
   /// See documentation:
   /// - [Standard events](https://developers.facebook.com/docs/app-events/best-practices#standard-events)
   /// - [Android constants](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/appevents/appeventsconstants.html)
@@ -321,11 +346,13 @@ class FacebookAppEvents {
     required String type,
     required String currency,
     required double price,
+    Map<String, dynamic>? parameters,
   }) {
     return logEvent(
       name: eventNameAddedToWishlist,
       parameters: {
-        paramNameContent: content != null ? json.encode(content) : null,
+        if (parameters != null) ...parameters,
+        if (content != null) paramNameContent: json.encode(content),
         paramNameContentId: id,
         paramNameContentType: type,
         paramNameCurrency: currency,
@@ -394,6 +421,9 @@ class FacebookAppEvents {
   /// Convenience wrapper around [logEvent] for the Initiated Checkout
   /// standard event.
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [totalPrice] (as valueToSum) and [currency] parameters.
+  ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logInitiatedCheckout({
@@ -403,15 +433,20 @@ class FacebookAppEvents {
     String? contentId,
     int? numItems,
     bool paymentInfoAvailable = false,
+    Map<String, dynamic>? parameters,
   }) {
+    if (totalPrice != null && currency == null) {
+      throw ArgumentError('currency must be provided if totalPrice is provided');
+    }
     return logEvent(
       name: eventNameInitiatedCheckout,
       valueToSum: totalPrice,
       parameters: {
-        paramNameContentType: contentType,
-        paramNameContentId: contentId,
-        paramNameNumItems: numItems,
-        paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
+        if (contentType != null) paramNameContentType: contentType,
+        if (contentId != null) paramNameContentId: contentId,
+        if (numItems != null) paramNameNumItems: numItems,
+        if (currency != null) paramNameCurrency: currency,
         paramNamePaymentInfoAvailable:
             paymentInfoAvailable ? paramValueYes : paramValueNo,
       },
@@ -440,18 +475,26 @@ class FacebookAppEvents {
 
   /// The start of a paid subscription for a product or service you offer.
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [price] (as valueToSum) and [currency] parameters.
+  ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logSubscribe({
     double? price,
     String? currency,
     required String orderId,
+    Map<String, dynamic>? parameters,
   }) {
+    if (price != null && currency == null) {
+      throw ArgumentError('currency must be provided if price is provided');
+    }
     return logEvent(
       name: eventNameSubscribe,
       valueToSum: price,
       parameters: {
-        paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
+        if (currency != null) paramNameCurrency: currency,
         paramNameOrderId: orderId,
       },
     );
@@ -459,18 +502,26 @@ class FacebookAppEvents {
 
   /// The start of a free trial of a product or service you offer (example: trial subscription).
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you should include the
+  /// [price] (as valueToSum) and [currency] parameters.
+  ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logStartTrial({
     double? price,
     String? currency,
     required String orderId,
+    Map<String, dynamic>? parameters,
   }) {
+    if (price != null && currency == null) {
+      throw ArgumentError('currency must be provided if price is provided');
+    }
     return logEvent(
       name: eventNameStartTrial,
       valueToSum: price,
       parameters: {
-        paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
+        if (currency != null) paramNameCurrency: currency,
         paramNameOrderId: orderId,
       },
     );

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -287,10 +287,6 @@ class FacebookAppEvents {
     double? price,
     Map<String, dynamic>? parameters,
   }) {
-    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
-    if (price != null && effectiveCurrency == null) {
-      throw ArgumentError('currency must be provided if price is provided');
-    }
     return logEvent(
       name: eventNameViewedContent,
       parameters: {
@@ -436,10 +432,6 @@ class FacebookAppEvents {
     bool paymentInfoAvailable = false,
     Map<String, dynamic>? parameters,
   }) {
-    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
-    if (totalPrice != null && effectiveCurrency == null) {
-      throw ArgumentError('currency must be provided if totalPrice is provided');
-    }
     return logEvent(
       name: eventNameInitiatedCheckout,
       valueToSum: totalPrice,
@@ -488,10 +480,6 @@ class FacebookAppEvents {
     required String orderId,
     Map<String, dynamic>? parameters,
   }) {
-    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
-    if (price != null && effectiveCurrency == null) {
-      throw ArgumentError('currency must be provided if price is provided');
-    }
     return logEvent(
       name: eventNameSubscribe,
       valueToSum: price,
@@ -516,10 +504,6 @@ class FacebookAppEvents {
     required String orderId,
     Map<String, dynamic>? parameters,
   }) {
-    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
-    if (price != null && effectiveCurrency == null) {
-      throw ArgumentError('currency must be provided if price is provided');
-    }
     return logEvent(
       name: eventNameStartTrial,
       valueToSum: price,

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -481,13 +481,19 @@ class FacebookAppEvents {
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdImpression({
-    required String adType,
+    String? adType,
+    String? currency,
+    double? valueToSum,
+    Map<String, dynamic>? parameters,
   }) {
     return logEvent(
       name: eventNameAdImpression,
       parameters: {
-        paramNameAdType: adType,
+        if (adType != null) paramNameAdType: adType,
+        if (currency != null) paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
       },
+      valueToSum: valueToSum,
     );
   }
 
@@ -496,13 +502,19 @@ class FacebookAppEvents {
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdClick({
-    required String adType,
+    String? adType,
+    String? currency,
+    double? valueToSum,
+    Map<String, dynamic>? parameters,
   }) {
     return logEvent(
       name: eventNameAdClick,
       parameters: {
-        paramNameAdType: adType,
+        if (adType != null) paramNameAdType: adType,
+        if (currency != null) paramNameCurrency: currency,
+        if (parameters != null) ...parameters,
       },
+      valueToSum: valueToSum,
     );
   }
 

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -287,7 +287,8 @@ class FacebookAppEvents {
     double? price,
     Map<String, dynamic>? parameters,
   }) {
-    if (price != null && currency == null) {
+    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
+    if (price != null && effectiveCurrency == null) {
       throw ArgumentError('currency must be provided if price is provided');
     }
     return logEvent(
@@ -435,7 +436,8 @@ class FacebookAppEvents {
     bool paymentInfoAvailable = false,
     Map<String, dynamic>? parameters,
   }) {
-    if (totalPrice != null && currency == null) {
+    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
+    if (totalPrice != null && effectiveCurrency == null) {
       throw ArgumentError('currency must be provided if totalPrice is provided');
     }
     return logEvent(
@@ -486,7 +488,8 @@ class FacebookAppEvents {
     required String orderId,
     Map<String, dynamic>? parameters,
   }) {
-    if (price != null && currency == null) {
+    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
+    if (price != null && effectiveCurrency == null) {
       throw ArgumentError('currency must be provided if price is provided');
     }
     return logEvent(
@@ -513,7 +516,8 @@ class FacebookAppEvents {
     required String orderId,
     Map<String, dynamic>? parameters,
   }) {
-    if (price != null && currency == null) {
+    final effectiveCurrency = currency ?? parameters?[paramNameCurrency];
+    if (price != null && effectiveCurrency == null) {
       throw ArgumentError('currency must be provided if price is provided');
     }
     return logEvent(
@@ -529,57 +533,63 @@ class FacebookAppEvents {
 
   /// Log this event when the user views an ad.
   ///
-  /// To be eligible for ad revenue optimization (ROAS), you must include the
-  /// [valueToSum] and [currency] parameters.
+  /// To track ad revenue for ROAS optimization, use [logEvent] directly with
+  /// [eventNameAdImpression], passing [valueToSum] (the ad revenue amount) and
+  /// [paramNameCurrency] in the parameters map:
+  ///
+  /// ```dart
+  /// logEvent(
+  ///   name: FacebookAppEvents.eventNameAdImpression,
+  ///   valueToSum: revenueAmount,
+  ///   parameters: {
+  ///     FacebookAppEvents.paramNameAdType: 'interstitial',
+  ///     FacebookAppEvents.paramNameCurrency: 'USD',
+  ///   },
+  /// );
+  /// ```
   ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/guides/maximize-in-app-ad-revenue
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdImpression({
-    String? adType,
-    String? currency,
-    double? valueToSum,
-    Map<String, dynamic>? parameters,
+    required String adType,
   }) {
-    if (valueToSum != null && currency == null) {
-      throw ArgumentError('currency must be provided if valueToSum is provided');
-    }
     return logEvent(
       name: eventNameAdImpression,
       parameters: {
-        if (parameters != null) ...parameters,
-        if (adType != null) paramNameAdType: adType,
-        if (currency != null) paramNameCurrency: currency,
+        paramNameAdType: adType,
       },
-      valueToSum: valueToSum,
     );
   }
 
   /// Log this event when the user clicks an ad.
   ///
-  /// To be eligible for ad revenue optimization (ROAS), you must include the
-  /// [valueToSum] and [currency] parameters.
+  /// To track ad revenue for ROAS optimization, use [logEvent] directly with
+  /// [eventNameAdClick], passing [valueToSum] (the ad revenue amount) and
+  /// [paramNameCurrency] in the parameters map:
+  ///
+  /// ```dart
+  /// logEvent(
+  ///   name: FacebookAppEvents.eventNameAdClick,
+  ///   valueToSum: revenueAmount,
+  ///   parameters: {
+  ///     FacebookAppEvents.paramNameAdType: 'rewarded_video',
+  ///     FacebookAppEvents.paramNameCurrency: 'USD',
+  ///   },
+  /// );
+  /// ```
   ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/app-events/guides/maximize-in-app-ad-revenue
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdClick({
-    String? adType,
-    String? currency,
-    double? valueToSum,
-    Map<String, dynamic>? parameters,
+    required String adType,
   }) {
-    if (valueToSum != null && currency == null) {
-      throw ArgumentError('currency must be provided if valueToSum is provided');
-    }
     return logEvent(
       name: eventNameAdClick,
       parameters: {
-        if (parameters != null) ...parameters,
-        if (adType != null) paramNameAdType: adType,
-        if (currency != null) paramNameCurrency: currency,
+        paramNameAdType: adType,
       },
-      valueToSum: valueToSum,
     );
   }
 

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -489,9 +489,9 @@ class FacebookAppEvents {
     return logEvent(
       name: eventNameAdImpression,
       parameters: {
+        if (parameters != null) ...parameters,
         if (adType != null) paramNameAdType: adType,
         if (currency != null) paramNameCurrency: currency,
-        if (parameters != null) ...parameters,
       },
       valueToSum: valueToSum,
     );
@@ -510,9 +510,9 @@ class FacebookAppEvents {
     return logEvent(
       name: eventNameAdClick,
       parameters: {
+        if (parameters != null) ...parameters,
         if (adType != null) paramNameAdType: adType,
         if (currency != null) paramNameCurrency: currency,
-        if (parameters != null) ...parameters,
       },
       valueToSum: valueToSum,
     );

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -478,7 +478,11 @@ class FacebookAppEvents {
 
   /// Log this event when the user views an ad.
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you must include the
+  /// [valueToSum] and [currency] parameters.
+  ///
   /// See documentation:
+  /// - https://developers.facebook.com/docs/app-events/guides/maximize-in-app-ad-revenue
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdImpression({
     String? adType,
@@ -486,6 +490,8 @@ class FacebookAppEvents {
     double? valueToSum,
     Map<String, dynamic>? parameters,
   }) {
+    assert(valueToSum == null || currency != null,
+        'currency must be provided if valueToSum is provided');
     return logEvent(
       name: eventNameAdImpression,
       parameters: {
@@ -499,7 +505,11 @@ class FacebookAppEvents {
 
   /// Log this event when the user clicks an ad.
   ///
+  /// To be eligible for ad revenue optimization (ROAS), you must include the
+  /// [valueToSum] and [currency] parameters.
+  ///
   /// See documentation:
+  /// - https://developers.facebook.com/docs/app-events/guides/maximize-in-app-ad-revenue
   /// - https://developers.facebook.com/docs/app-events/best-practices#standard-events
   Future<void> logAdClick({
     String? adType,
@@ -507,6 +517,8 @@ class FacebookAppEvents {
     double? valueToSum,
     Map<String, dynamic>? parameters,
   }) {
+    assert(valueToSum == null || currency != null,
+        'currency must be provided if valueToSum is provided');
     return logEvent(
       name: eventNameAdClick,
       parameters: {

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -45,12 +45,8 @@ void main() {
       );
     });
 
-    test('logAdImpression forwards parameters', () async {
-      await facebookAppEvents.logAdImpression(
-        adType: 'interstitial',
-        currency: 'USD',
-        valueToSum: 1.23,
-      );
+    test('logAdImpression forwards adType', () async {
+      await facebookAppEvents.logAdImpression(adType: 'interstitial');
 
       expect(
         methodCall,
@@ -60,42 +56,9 @@ void main() {
             'name': 'AdImpression',
             'parameters': <String, dynamic>{
               'fb_ad_type': 'interstitial',
-              'fb_currency': 'USD',
-            },
-            '_valueToSum': 1.23,
-          },
-        ),
-      );
-    });
-
-    test('logAdImpression handles custom parameters and overrides', () async {
-      await facebookAppEvents.logAdImpression(
-        adType: 'interstitial',
-        parameters: {
-          'fb_ad_type': 'SHOULD_BE_OVERRIDDEN',
-          'custom_param': 'value',
-        },
-      );
-
-      expect(
-        methodCall,
-        isMethodCall(
-          'logEvent',
-          arguments: <String, dynamic>{
-            'name': 'AdImpression',
-            'parameters': <String, dynamic>{
-              'fb_ad_type': 'interstitial',
-              'custom_param': 'value',
             },
           },
         ),
-      );
-    });
-
-    test('logAdImpression throws ArgumentError if valueToSum given without currency', () {
-      expect(
-        () => facebookAppEvents.logAdImpression(valueToSum: 1.23),
-        throwsArgumentError,
       );
     });
 
@@ -162,12 +125,8 @@ void main() {
       );
     });
 
-    test('logAdClick forwards parameters', () async {
-      await facebookAppEvents.logAdClick(
-        adType: 'rewarded_video',
-        currency: 'EUR',
-        valueToSum: 2.34,
-      );
+    test('logAdClick forwards adType', () async {
+      await facebookAppEvents.logAdClick(adType: 'rewarded_video');
 
       expect(
         methodCall,
@@ -177,11 +136,30 @@ void main() {
             'name': 'AdClick',
             'parameters': <String, dynamic>{
               'fb_ad_type': 'rewarded_video',
-              'fb_currency': 'EUR',
             },
-            '_valueToSum': 2.34,
           },
         ),
+      );
+    });
+
+    test('logViewContent throws ArgumentError if price given without currency', () {
+      expect(
+        () => facebookAppEvents.logViewContent(price: 9.99),
+        throwsArgumentError,
+      );
+    });
+
+    test('logSubscribe throws ArgumentError if price given without currency', () {
+      expect(
+        () => facebookAppEvents.logSubscribe(orderId: 'order123', price: 4.99),
+        throwsArgumentError,
+      );
+    });
+
+    test('logStartTrial throws ArgumentError if price given without currency', () {
+      expect(
+        () => facebookAppEvents.logStartTrial(orderId: 'order123', price: 1.99),
+        throwsArgumentError,
       );
     });
   });

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -99,6 +99,69 @@ void main() {
       );
     });
 
+    test('logViewContent handles custom parameters and overrides', () async {
+      await facebookAppEvents.logViewContent(
+        id: 'id123',
+        currency: 'USD',
+        price: 9.99,
+        parameters: {
+          'fb_content_id': 'SHOULD_BE_OVERRIDDEN',
+          'custom_param': 'value',
+        },
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_content_view',
+            'parameters': <String, dynamic>{
+              'fb_content_id': 'id123',
+              'fb_currency': 'USD',
+              'custom_param': 'value',
+            },
+            '_valueToSum': 9.99,
+          },
+        ),
+      );
+    });
+
+    test('logSubscribe handles custom parameters and overrides', () async {
+      await facebookAppEvents.logSubscribe(
+        orderId: 'order123',
+        currency: 'USD',
+        price: 4.99,
+        parameters: {
+          'fb_order_id': 'SHOULD_BE_OVERRIDDEN',
+          'custom_param': 'value',
+        },
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'Subscribe',
+            'parameters': <String, dynamic>{
+              'fb_order_id': 'order123',
+              'fb_currency': 'USD',
+              'custom_param': 'value',
+            },
+            '_valueToSum': 4.99,
+          },
+        ),
+      );
+    });
+
+    test('logInitiatedCheckout throws ArgumentError if totalPrice given without currency', () {
+      expect(
+        () => facebookAppEvents.logInitiatedCheckout(totalPrice: 10.0),
+        throwsArgumentError,
+      );
+    });
+
     test('logAdClick forwards parameters', () async {
       await facebookAppEvents.logAdClick(
         adType: 'rewarded_video',

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -92,6 +92,13 @@ void main() {
       );
     });
 
+    test('logAdImpression throws ArgumentError if valueToSum given without currency', () {
+      expect(
+        () => facebookAppEvents.logAdImpression(valueToSum: 1.23),
+        throwsArgumentError,
+      );
+    });
+
     test('logAdClick forwards parameters', () async {
       await facebookAppEvents.logAdClick(
         adType: 'rewarded_video',

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -118,13 +118,6 @@ void main() {
       );
     });
 
-    test('logInitiatedCheckout throws ArgumentError if totalPrice given without currency', () {
-      expect(
-        () => facebookAppEvents.logInitiatedCheckout(totalPrice: 10.0),
-        throwsArgumentError,
-      );
-    });
-
     test('logAdClick forwards adType', () async {
       await facebookAppEvents.logAdClick(adType: 'rewarded_video');
 
@@ -142,26 +135,6 @@ void main() {
       );
     });
 
-    test('logViewContent throws ArgumentError if price given without currency', () {
-      expect(
-        () => facebookAppEvents.logViewContent(price: 9.99),
-        throwsArgumentError,
-      );
-    });
-
-    test('logSubscribe throws ArgumentError if price given without currency', () {
-      expect(
-        () => facebookAppEvents.logSubscribe(orderId: 'order123', price: 4.99),
-        throwsArgumentError,
-      );
-    });
-
-    test('logStartTrial throws ArgumentError if price given without currency', () {
-      expect(
-        () => facebookAppEvents.logStartTrial(orderId: 'order123', price: 1.99),
-        throwsArgumentError,
-      );
-    });
   });
 
   group('Purchase logging', () {

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -118,6 +118,60 @@ void main() {
       );
     });
 
+    test('logCompletedRegistration handles custom parameters and overrides', () async {
+      await facebookAppEvents.logCompletedRegistration(
+        registrationMethod: 'email',
+        parameters: {
+          'fb_registration_method': 'SHOULD_BE_OVERRIDDEN',
+          'custom_param': 'value',
+        },
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_complete_registration',
+            'parameters': <String, dynamic>{
+              'fb_registration_method': 'email',
+              'custom_param': 'value',
+            },
+          },
+        ),
+      );
+    });
+
+    test('logAddToCart handles custom parameters and overrides', () async {
+      await facebookAppEvents.logAddToCart(
+        id: 'item-1',
+        type: 'product',
+        currency: 'USD',
+        price: 9.99,
+        parameters: {
+          'fb_content_id': 'SHOULD_BE_OVERRIDDEN',
+          'custom_param': 'value',
+        },
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_add_to_cart',
+            'parameters': <String, dynamic>{
+              'fb_content_id': 'item-1',
+              'fb_content_type': 'product',
+              'fb_currency': 'USD',
+              'custom_param': 'value',
+            },
+            '_valueToSum': 9.99,
+          },
+        ),
+      );
+    });
+
     test('logAdClick forwards adType', () async {
       await facebookAppEvents.logAdClick(adType: 'rewarded_video');
 

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -44,6 +44,52 @@ void main() {
         ),
       );
     });
+
+    test('logAdImpression forwards parameters', () async {
+      await facebookAppEvents.logAdImpression(
+        adType: 'interstitial',
+        currency: 'USD',
+        valueToSum: 1.23,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'AdImpression',
+            'parameters': <String, dynamic>{
+              'fb_ad_type': 'interstitial',
+              'fb_currency': 'USD',
+            },
+            '_valueToSum': 1.23,
+          },
+        ),
+      );
+    });
+
+    test('logAdClick forwards parameters', () async {
+      await facebookAppEvents.logAdClick(
+        adType: 'rewarded_video',
+        currency: 'EUR',
+        valueToSum: 2.34,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'AdClick',
+            'parameters': <String, dynamic>{
+              'fb_ad_type': 'rewarded_video',
+              'fb_currency': 'EUR',
+            },
+            '_valueToSum': 2.34,
+          },
+        ),
+      );
+    });
   });
 
   group('Purchase logging', () {

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -68,6 +68,30 @@ void main() {
       );
     });
 
+    test('logAdImpression handles custom parameters and overrides', () async {
+      await facebookAppEvents.logAdImpression(
+        adType: 'interstitial',
+        parameters: {
+          'fb_ad_type': 'SHOULD_BE_OVERRIDDEN',
+          'custom_param': 'value',
+        },
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'AdImpression',
+            'parameters': <String, dynamic>{
+              'fb_ad_type': 'interstitial',
+              'custom_param': 'value',
+            },
+          },
+        ),
+      );
+    });
+
     test('logAdClick forwards parameters', () async {
       await facebookAppEvents.logAdClick(
         adType: 'rewarded_video',


### PR DESCRIPTION
Addresses #480.

### What changed

**`logAdImpression` / `logAdClick` — documentation only**
The native Meta SDK convenience methods only accept `adType`. Revenue data for ROAS tracking belongs to the underlying `logEvent` call. The docstrings now include a code example showing the correct pattern:

```dart
facebookAppEvents.logEvent(
  name: FacebookAppEvents.eventNameAdImpression,
  valueToSum: revenueAmount,
  parameters: {
    FacebookAppEvents.paramNameAdType: 'interstitial',
    FacebookAppEvents.paramNameCurrency: 'USD',
  },
);
```

**Custom `parameters` map added to all convenience methods**
`logCompletedRegistration`, `logRated`, `logViewContent`, `logAddToCart`, `logAddToWishlist`, `logInitiatedCheckout`, `logSubscribe`, `logStartTrial` all gain an optional `Map<String, dynamic>? parameters` argument for passing extra parameters without dropping down to raw `logEvent`. Named parameters always take precedence over the map.

**Null-safe parameter handling**
Parameters are now only included in the map if non-null (using `if (x != null) key: value`), making the behavior explicit rather than relying on downstream `_filterOutNulls`.

**ROAS documentation**
Doc comments on revenue-related events note that including `currency` alongside `valueToSum`/`price` is required for ROAS eligibility.

### Design principles
- No `ArgumentError` validation — the native SDK does not validate pairings; adding throws would be a breaking change.
- 1:1 mapping with native SDK API surfaces; convenience methods do not invent parameters the native SDK doesn't have.