### PR TITLE
fix: guard kotlin-android plugin apply for AGP 9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.27.1
+
+- Guard `apply plugin: "kotlin-android"` against AGP 9, which ships with built-in Kotlin support (`android.builtInKotlin=true`) and conflicts with the explicit plugin application. Keeps AGP < 9 behavior unchanged (fixes [#482](https://github.com/oddbit/flutter_facebook_app_events/issues/482)).
+
 ## 0.27.0
 
 - Added `parameters` argument to shorthand log methods (`logCompletedRegistration`, `logRated`, `logViewContent`, `logAddToCart`, `logAddedToWishlist`, `logInitiatedCheckout`, `logSubscribe`, `logStartTrial`) to support custom event parameters alongside standard ones.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,13 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// AGP 9 enables built-in Kotlin support by default (android.builtInKotlin=true),
+// which conflicts with applying kotlin-android explicitly. Guard for AGP < 9.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.split('\\.')[0].toInteger()
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     namespace "id.oddbit.flutter.facebook_app_events"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.27.0
+version: 0.27.1
 homepage: https://oddb.it/app-events-pubspec
 
 environment:


### PR DESCRIPTION
## Summary

- AGP 9 ships with `android.builtInKotlin=true` by default, causing a plugin conflict when `kotlin-android` is also applied explicitly.
- Guard the explicit `apply plugin: "kotlin-android"` behind an AGP major-version check so AGP < 9 keeps current behavior and AGP 9 consumers are unblocked.
- Bump version to `0.27.1` and update `CHANGELOG.md`.

Fixes #482

## Test plan

- [ ] Build `example/` with the current AGP 8.9.2 toolchain and confirm the plugin still compiles and runs (no behavior change for AGP < 9).
- [ ] Smoke-test a consumer project pinned to AGP 9 to verify the `kotlin-android` plugin conflict no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)