### PR TITLE
chore: consistency cleanup and version-sync fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repo.
+
+## Before making changes
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and follow the guidelines in it. In particular, the **Release Process** section lists files that must stay in sync (e.g. `pubspec.yaml` and `ios/facebook_app_events.podspec` versions) — consult it before preparing a release or bumping the version.
+
+## Plugin architecture
+
+This plugin exposes Meta's Facebook App Events SDK to Flutter with an explicit 1:1 mapping between the Dart API and the native handlers. When adding, renaming, or modifying a method, keep the three layers in sync:
+
+- `lib/facebook_app_events.dart` — Dart API + MethodChannel invocation
+- `android/src/main/kotlin/.../FacebookAppEventsPlugin.kt` — Android handler
+- `ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift` — iOS handler
+
+The MethodChannel name is `flutter.oddbit.id/facebook_app_events`.
+
+## Facebook SDK version policy
+
+The plugin follows the **major** version of the Facebook SDK (currently v18.x). Dependency ranges should stay major-only:
+
+- Android (`android/build.gradle`): `com.facebook.android:facebook-android-sdk:[18.0,19.0)`
+- iOS CocoaPods (`ios/facebook_app_events.podspec`): `FBSDKCoreKit`, `~> 18.0`
+- iOS SPM (`ios/facebook_app_events/Package.swift`): `"18.0.0"..<"19.0.0"`
+
+## Known platform divergence
+
+- `setDataProcessingOptions`: functional on Android; no-op on iOS (Meta removed the API in FBSDK 18.x). Documented in the Dart dartdoc and README "Known Limitations".
+- Graph API version override: plugin forces `v24.0` at init on both platforms to work around outdated SDK defaults. Revisit when FBSDK v19 lands.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,12 @@ We are committed to fostering a welcoming and respectful community. By participa
 
 ## Release Process
 
-To trigger a release deployment, create and push a tag in the format `v<major>.<minor>.<patch>`. For example:
+Before tagging a release, update the version in **both** of these files — they must match, otherwise CocoaPods consumers resolve the wrong version:
+
+- `pubspec.yaml` — `version:` field
+- `ios/facebook_app_events.podspec` — `s.version` field
+
+Then update `CHANGELOG.md` and create and push a tag in the format `v<major>.<minor>.<patch>`. For example:
 ```bash
 git tag v1.2.3
 git push origin v1.2.3

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Refer to Meta's [Graph API changelog](https://developers.facebook.com/docs/graph
 
 This is a plugin-specific workaround for a [known upstream issue in the iOS SDK](https://github.com/facebook/facebook-ios-sdk/issues/2610) and [Android SDK](https://github.com/facebook/facebook-android-sdk/issues/1308). When Meta releases SDK v19.x with a corrected default, this override will become a no-op and the method can safely be removed from your code.
 
+### `setDataProcessingOptions` on iOS
+
+`setDataProcessingOptions` is **functional on Android** but is a **no-op on iOS** (a warning is printed). Meta removed the underlying API from the Facebook iOS SDK in the 18.x series; there is no native replacement callable from the SDK. If you need to configure data use on iOS, use Meta's [Data Use Checkup](https://developers.facebook.com/docs/development/data-processing-options) tooling in the app dashboard instead.
+
 ### Facebook Event Manager "Please Upgrade SDK" Warning
 
 When setting up codeless events in Facebook Event Manager, you may encounter a warning message stating:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        targetSdk = 35
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+# platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.27.0"
+    version: "0.27.1"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the facebook_app_events plugin.
 publish_to: 'none'
 version: 0.0.1+1
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
   flutter:

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'facebook_app_events'
-  s.version          = '0.25.0'
+  s.version          = '0.27.1'
   s.summary          = 'Flutter plugin for Facebook Analytics and App Events'
   s.description      = <<-DESC
 Flutter plugin for Facebook Analytics and App Events

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -321,5 +321,209 @@ void main() {
         ),
       );
     });
+
+    test('setAutoLogAppEventsEnabled forwards boolean', () async {
+      await facebookAppEvents.setAutoLogAppEventsEnabled(true);
+
+      expect(
+        methodCall,
+        isMethodCall('setAutoLogAppEventsEnabled', arguments: true),
+      );
+    });
+
+    test('setAdvertiserTracking forwards enabled and collectId', () async {
+      await facebookAppEvents.setAdvertiserTracking(
+        enabled: true,
+        collectId: false,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'setAdvertiserTracking',
+          arguments: <String, dynamic>{
+            'enabled': true,
+            'collectId': false,
+          },
+        ),
+      );
+    });
+
+    test('setDataProcessingOptions forwards options, country, state', () async {
+      await facebookAppEvents.setDataProcessingOptions(
+        ['LDU'],
+        country: 1,
+        state: 1000,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'setDataProcessingOptions',
+          arguments: <String, dynamic>{
+            'options': ['LDU'],
+            'country': 1,
+            'state': 1000,
+          },
+        ),
+      );
+    });
+  });
+
+  group('User lifecycle', () {
+    test('setUserID forwards id as scalar argument', () async {
+      await facebookAppEvents.setUserID('user-42');
+
+      expect(methodCall, isMethodCall('setUserID', arguments: 'user-42'));
+    });
+
+    test('clearUserID sends no arguments', () async {
+      await facebookAppEvents.clearUserID();
+
+      expect(methodCall, isMethodCall('clearUserID', arguments: null));
+    });
+
+    test('clearUserData sends no arguments', () async {
+      await facebookAppEvents.clearUserData();
+
+      expect(methodCall, isMethodCall('clearUserData', arguments: null));
+    });
+
+    test('flush sends no arguments', () async {
+      await facebookAppEvents.flush();
+
+      expect(methodCall, isMethodCall('flush', arguments: null));
+    });
+
+    test('getApplicationId invokes channel method', () async {
+      await facebookAppEvents.getApplicationId();
+
+      expect(methodCall, isMethodCall('getApplicationId', arguments: null));
+    });
+
+    test('getAnonymousId invokes channel method', () async {
+      await facebookAppEvents.getAnonymousId();
+
+      expect(methodCall, isMethodCall('getAnonymousId', arguments: null));
+    });
+  });
+
+  group('Push notifications', () {
+    test('logPushNotificationOpen forwards payload and action', () async {
+      await facebookAppEvents.logPushNotificationOpen(
+        payload: {'campaign': 'spring-sale'},
+        action: 'opened',
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logPushNotificationOpen',
+          arguments: <String, dynamic>{
+            'payload': {'campaign': 'spring-sale'},
+            'action': 'opened',
+          },
+        ),
+      );
+    });
+  });
+
+  group('Standard event shorthands', () {
+    test('logRated forwards valueToSum and parameters', () async {
+      await facebookAppEvents.logRated(
+        valueToSum: 4.5,
+        parameters: {'content_id': 'sku-1'},
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_rate',
+            'parameters': <String, dynamic>{'content_id': 'sku-1'},
+            '_valueToSum': 4.5,
+          },
+        ),
+      );
+    });
+
+    test('logInitiatedCheckout forwards totalPrice, currency, numItems',
+        () async {
+      await facebookAppEvents.logInitiatedCheckout(
+        totalPrice: 49.99,
+        currency: 'USD',
+        contentType: 'product',
+        contentId: 'sku-1',
+        numItems: 2,
+        paymentInfoAvailable: true,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_initiated_checkout',
+            'parameters': <String, dynamic>{
+              'fb_content_type': 'product',
+              'fb_content_id': 'sku-1',
+              'fb_num_items': 2,
+              'fb_currency': 'USD',
+              'fb_payment_info_available': '1',
+            },
+            '_valueToSum': 49.99,
+          },
+        ),
+      );
+    });
+
+    test('logStartTrial forwards orderId, price, currency', () async {
+      await facebookAppEvents.logStartTrial(
+        orderId: 'order-9',
+        price: 0.0,
+        currency: 'USD',
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'StartTrial',
+            'parameters': <String, dynamic>{
+              'fb_currency': 'USD',
+              'fb_order_id': 'order-9',
+            },
+            '_valueToSum': 0.0,
+          },
+        ),
+      );
+    });
+
+    test('logAddToWishlist forwards required fields and price', () async {
+      await facebookAppEvents.logAddToWishlist(
+        id: 'sku-7',
+        type: 'product',
+        currency: 'EUR',
+        price: 19.5,
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'fb_mobile_add_to_wishlist',
+            'parameters': <String, dynamic>{
+              'fb_content_id': 'sku-7',
+              'fb_content_type': 'product',
+              'fb_currency': 'EUR',
+            },
+            '_valueToSum': 19.5,
+          },
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Deep code review pass for consistency with current stable releases (FBSDK 18.x on both platforms, Flutter 3.41 / Dart 3.11, AGP 8.9.x / Kotlin 2.3.x) and with the plugin's 1:1 Dart ↔ native SDK correspondence goal. No native handler changes, no Facebook SDK bumps — all 15 Dart methods already map cleanly to both platforms.

**Version drift (P0)**

- Bump `ios/facebook_app_events.podspec` from `0.25.0` → `0.27.1` so CocoaPods consumers stop resolving the wrong version. It had been stale across v0.26.x and v0.27.x.
- Add a release-process note to `CONTRIBUTING.md` requiring both `pubspec.yaml` and the podspec to be bumped in the same commit.
- New `CLAUDE.md` pointing at `CONTRIBUTING.md` and documenting the 1:1 contract + known platform divergences so agent-assisted changes stay on track.

**Platform divergence (P1)**

- `setDataProcessingOptions` is functional on Android but a no-op on iOS (Meta removed the API in FBSDK 18.x). Added a Known Limitations section to `README.md` pointing iOS users at Meta's Data Use Checkup tooling. The Dart dartdoc already documents this.

**Example app modernization (P1)**

- `example/pubspec.yaml`: raise `sdk` to `>=3.3.0 <4.0.0` and `flutter` to `>=3.19.0` to match the plugin's own floor (was `>=2.12.0` / `>=2.0.0`, which advertised broader support than actually works).
- `example/ios/Podfile`: update stale commented hint `12.0` → `13.0` (plugin requires iOS 13 since v0.26.0).

**Android cleanliness (P2)**

- `android/build.gradle`: set `targetSdk = 35` explicitly. `buildConfig = true` is kept — `FacebookAppEventsPlugin.kt:155` reads `BuildConfig.DEBUG`.

**Test coverage (P2)**

- Added 14 channel-call tests for previously-uncovered public methods: `clearUserData`, `clearUserID`, `flush`, `getApplicationId`, `getAnonymousId`, `setUserID`, `setAutoLogAppEventsEnabled`, `setDataProcessingOptions`, `setAdvertiserTracking`, `logPushNotificationOpen`, `logRated`, `logInitiatedCheckout`, `logStartTrial`, `logAddToWishlist`. 29 tests total, all passing.

## Test plan

- [x] `flutter pub get` clean
- [x] `flutter analyze` clean on the plugin (2 pre-existing info-level issues in `example/lib/main.dart` untouched by this PR)
- [x] `flutter test` — all 29 tests pass
- [ ] `cd example && flutter build apk --debug` (needs Android toolchain; not run in my environment)
- [ ] `cd example/ios && pod install` — verifies podspec 0.27.1 resolves cleanly
- [ ] Example app smoke test in Events Manager "Test Events"
- [x] Version sync: `pubspec.yaml` and `ios/facebook_app_events.podspec` both at 0.27.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)