### PR TITLE
docs: add commercial-support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,20 @@ question to [StackOverflow](https://stackoverflow.com/search?q=facebook+app+even
 Feel free to open a thread if you are having any questions on how to use either the Facebook App Events as a reporting tool
 itself or even on how to use this plugin. 
 
+## Need help shipping it?
+
+This plugin is free and open source. But wiring up Meta attribution end to end —
+consent flows, iOS ATT and SKAdNetwork, and getting events to actually land in
+Events Manager — can get fiddly. If your team is integrating App Events and hits a
+wall, or you'd just like an experienced pair of hands, [Oddbit](https://oddb.it/website)
+is happy to help.
+
+We're a senior-led studio (based in Indonesia, with roots in Sweden) shipping Flutter,
+Firebase, and analytics integrations. `facebook_app_events` is one of the open-source
+tools we maintain and use ourselves.
+
+[Talk to us at oddbit.id →](https://oddb.it/website)
+
 ## Getting involved
 First of all, thank you for even considering to get involved. You are a real super :star: and we :heart: you! 
 


### PR DESCRIPTION
## Summary

Adds a brief, clearly-labeled **"Need help shipping it?"** section to the README, soft-offering Oddbit's help with Meta App Events integration (consent, iOS ATT/SKAdNetwork, Events Manager debugging).

## Placement & tone

- Sits **below** the documentation — after "Discussions and ideas" (free/community help) and before "Getting involved" (contribution) — so it reads as a natural escalation, not a top-of-page banner.
- One short section, framed around genuine user value, a single outbound link, no logo banner or repeated CTAs.

## pub.dev policy

The self-promotion/spam policy targets packages that are *primarily* advertising, keyword-stuffed, or misleading. A single modest commercial-support section beneath the real docs is common and accepted on pub.dev, and leaves docs/examples (and therefore pub points) untouched.

## Notes

- Branched off the latest `main`; independent of the 0.28.0 work in #487. Both touch the README but in different sections, so they merge cleanly in any order.
- Docs-only change — no code, tests, or version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
