### PR TITLE
fix: restore native SDK parity (data processing options, user data semantics, parameter validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+- **Fix (iOS):** `setDataProcessingOptions` is now functional on iOS, mapping to `Settings.shared.setDataProcessingOptions(options, country:state:)`. The previous no-op was based on the incorrect belief that Meta removed the API in Facebook iOS SDK 18.x — it exists in all 18.x releases. The "no-op on iOS" known limitation is gone.
+- **Fix (iOS):** `getApplicationId` now returns `Settings.shared.appID` (which also resolves the `Info.plist` `FacebookAppID`) instead of reading `Info.plist` directly, so programmatic app-id configuration is reflected, matching Android.
+- **Fix (iOS):** `setUserData` now uses merge semantics like Android: only the fields you pass are updated. Previously the iOS handler passed `nil` for absent fields, which *cleared* previously-set fields on iOS while Android kept them. Use `clearUserData`/`clearUserDataForType` to remove fields.
+- **Fix:** event parameters are validated in the Dart layer. The native SDKs accept only `String`/numeric parameter values and **silently drop** the entire event otherwise — booleans (previously dropped on Android, recorded on iOS) are now converted to `"1"`/`"0"` on both platforms, and unsupported types (lists, maps) throw an `ArgumentError` instead of vanishing. JSON-encode structured values instead.
+- **Fix (iOS):** the `activateApp(applicationId:)` override now applies per call: calling `activateApp()` without an id resets `loggingOverrideAppID`, matching Android's per-call fallback to the default app id.
+- **Fix (Android):** `logPurchase`/`logProductItem` now return an `INVALID_ARGUMENT` error for invalid ISO 4217 currency codes instead of an opaque platform exception.
+- Add `externalId` to `setUserData` and `FacebookUserDataField` (Meta advanced matching `extern_id`), supported by both native SDKs.
+- Add `setLimitEventAndDataUsage(bool)`, mapping to `FacebookSdk.setLimitEventAndDataUsage` (Android) / `Settings.shared.isEventDataUsageLimited` (iOS).
+- Add `setAdvertiserIdCollectionEnabled(bool)` and deprecate `setAdvertiserTracking`: the iOS tracking flag it set is deprecated since FBSDK v17 (ATT status is used instead), and on Android only advertiser ID collection exists.
+- Add `setPushNotificationsDeviceToken(String)` (native SDK naming) and deprecate `setPushNotificationToken`, which now delegates to it.
+- Document the plugin's API scope (intentionally unexposed native APIs) in the README.
+
 ## 0.29.0
 
 - **iOS UISceneDelegate adoption.** Adopt `FlutterSceneLifeCycleDelegate` and register as a scene delegate so Facebook URL callbacks (deep links / deferred app links) still reach the SDK on apps using the UIScene lifecycle — the default for Flutter 3.38+. The legacy `application(_:open:options:)` path is retained for non-UIScene apps (fixes [#489](https://github.com/oddbit/flutter_facebook_app_events/issues/489)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,5 +26,7 @@ The plugin follows the **major** version of the Facebook SDK (currently v18.x). 
 
 ## Known platform divergence
 
-- `setDataProcessingOptions`: functional on Android; no-op on iOS (Meta removed the API in FBSDK 18.x). Documented in the Dart dartdoc and README "Known Limitations".
+- `clearUserDataForType`: functional on iOS; no-op on Android (the Android `AppEventsLogger` has no per-field clear). Documented in the Dart dartdoc and README "Known Limitations".
+- `setUserData` uses merge semantics on both platforms: only fields present in the call are updated. The iOS handler deliberately skips absent keys because passing nil to the native setter would *clear* the field on iOS (Android ignores nulls).
 - Graph API version override: plugin forces `v24.0` at init on both platforms to work around outdated SDK defaults. Revisit when FBSDK v19 lands.
+- Event parameters are validated in the Dart layer (`String`/`num`/`bool` only, bool sent as `"1"`/`"0"`) because the native SDKs silently drop events with other value types.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Please refer to the official SDK documentation for correct and expected behavior
 [report an issue](https://oddb.it/3wd)
 if you find anything that is not working according to official documentation.
 
+### API scope
+
+The plugin mirrors the App Events surface of the native SDKs 1:1 — if a method exists on `AppEvents` (iOS) / `AppEventsLogger` or the related `Settings` / `FacebookSdk` toggles (Android), you should find it here under the same name. A few native APIs are intentionally **not** exposed because they don't translate to Flutter: the access-token overloads of `logEvent`/`logPurchase`, hybrid-webview augmentation (`augmentWebView` / `augmentHybridWebView`), the Unity integration hooks, and iOS-only `logFailedStoreKit2Purchase`. If you need one of these, please [open an issue](https://oddb.it/3wd).
+
 ## Dependencies on Facebook SDK
 Every now and then it is necessary for this plugin to update the Facebook SDK dependency. We follow the major
 version of the current Facebook SDK in order to be as compatible as possible with other dependencies in your
@@ -154,9 +158,9 @@ Refer to Meta's [Graph API changelog](https://oddb.it/ku2) for currently active 
 
 This is a plugin-specific workaround for a [known upstream issue in the iOS SDK](https://oddb.it/y8r) and [Android SDK](https://oddb.it/gmy). When Meta releases SDK v19.x with a corrected default, this override will become a no-op and the method can safely be removed from your code.
 
-### `setDataProcessingOptions` on iOS
+### Event parameter values
 
-`setDataProcessingOptions` is **functional on Android** but is a **no-op on iOS** (a warning is printed). Meta removed the underlying API from the Facebook iOS SDK in the 18.x series; there is no native replacement callable from the SDK. If you need to configure data use on iOS, use Meta's [Data Use Checkup](https://oddb.it/gnc) tooling in the app dashboard instead.
+The native Facebook SDKs only accept `String` and numeric event parameter values — an event carrying any other value type is **silently dropped** by the SDK. To protect against that, `logEvent` (and the helpers that route through it) accepts `String`, `num`, and `bool` values: booleans are converted to `"1"`/`"0"` (Meta's yes/no convention) so events are recorded identically on both platforms, and any other value type throws an `ArgumentError`. Encode structured values (lists, maps) as a JSON string first, as Meta prescribes for parameters like `fb_content`.
 
 ### `clearUserDataForType` on Android
 

--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -8,6 +8,7 @@ package id.oddbit.flutter.facebook_app_events
 import androidx.annotation.NonNull
 
 import android.app.Application
+import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import com.facebook.FacebookSdk
@@ -34,11 +35,13 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
   private val logTag = "FacebookAppEvents"
 
   private var application: Application? = null
+  private var applicationContext: Context? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter.oddbit.id/facebook_app_events")
     channel.setMethodCallHandler(this)
 
+    applicationContext = flutterPluginBinding.applicationContext
     application = flutterPluginBinding.applicationContext.applicationContext as? Application
     appEventsLogger = AppEventsLogger.newLogger(flutterPluginBinding.applicationContext)
     anonymousId = AppEventsLogger.getAnonymousAppDeviceGUID(flutterPluginBinding.applicationContext)
@@ -53,6 +56,7 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     application = null
+    applicationContext = null
     channel.setMethodCallHandler(null)
   }
 
@@ -72,9 +76,11 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
       "getAnonymousId" -> handleGetAnonymousId(call, result)
       "logPurchase" -> handlePurchased(call, result)
       "setAdvertiserTracking" -> handleSetAdvertiserTracking(call, result)
+      "setAdvertiserIdCollectionEnabled" -> handleSetAdvertiserIdCollectionEnabled(call, result)
+      "setLimitEventAndDataUsage" -> handleSetLimitEventAndDataUsage(call, result)
       "setGraphApiVersion" -> handleSetGraphApiVersion(call, result)
       "logProductItem" -> handleLogProductItem(call, result)
-      "setPushNotificationToken" -> handleSetPushNotificationToken(call, result)
+      "setPushNotificationsDeviceToken", "setPushNotificationToken" -> handleSetPushNotificationToken(call, result)
       "setFlushBehavior" -> handleSetFlushBehavior(call, result)
       "getFlushBehavior" -> handleGetFlushBehavior(call, result)
       "getUserData" -> handleGetUserData(call, result)
@@ -107,20 +113,23 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
   }
 
   private fun handleSetUserData(call: MethodCall, result: Result) {
-    val parameters = call.arguments as? Map<String, Any?> ?: emptyMap()
-    val parameterBundle = createBundleFromMap(parameters)
+    val arguments = call.arguments as? Map<String, Any?> ?: emptyMap()
 
+    // Merge semantics: the native SDK only stores non-null fields and leaves
+    // previously-set fields untouched, matching the iOS handler. Clearing is
+    // done explicitly via clearUserData.
     AppEventsLogger.setUserData(
-      parameterBundle?.getString("email"),
-      parameterBundle?.getString("firstName"),
-      parameterBundle?.getString("lastName"),
-      parameterBundle?.getString("phone"),
-      parameterBundle?.getString("dateOfBirth"),
-      parameterBundle?.getString("gender"),
-      parameterBundle?.getString("city"),
-      parameterBundle?.getString("state"),
-      parameterBundle?.getString("zip"),
-      parameterBundle?.getString("country")
+      arguments["email"] as? String,
+      arguments["firstName"] as? String,
+      arguments["lastName"] as? String,
+      arguments["phone"] as? String,
+      arguments["dateOfBirth"] as? String,
+      arguments["gender"] as? String,
+      arguments["city"] as? String,
+      arguments["state"] as? String,
+      arguments["zip"] as? String,
+      arguments["country"] as? String,
+      arguments["externalId"] as? String
     )
 
     result.success(null)
@@ -159,6 +168,23 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
 
     FacebookSdk.setAdvertiserIDCollectionEnabled(enabled && collectId)
 
+    result.success(null)
+  }
+
+  private fun handleSetAdvertiserIdCollectionEnabled(call: MethodCall, result: Result) {
+    val enabled = call.arguments as? Boolean ?: false
+    FacebookSdk.setAdvertiserIDCollectionEnabled(enabled)
+    result.success(null)
+  }
+
+  private fun handleSetLimitEventAndDataUsage(call: MethodCall, result: Result) {
+    val context = applicationContext
+    if (context == null) {
+      result.error("missing_context", "could not set limitEventAndDataUsage: Android context is missing", null)
+      return
+    }
+    val enabled = call.arguments as? Boolean ?: false
+    FacebookSdk.setLimitEventAndDataUsage(context, enabled)
     result.success(null)
   }
 
@@ -268,7 +294,11 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
       result.error("INVALID_ARGUMENT", "Amount and currency are required", null)
       return
     }
-    val currency = Currency.getInstance(currencyCode)
+    val currency = currencyFromCode(currencyCode)
+    if (currency == null) {
+      result.error("INVALID_ARGUMENT", "'$currencyCode' is not a valid ISO 4217 currency code", null)
+      return
+    }
     val parameters = call.argument<Map<String, Any>>("parameters")
     val parameterBundle = createBundleFromMap(parameters) ?: Bundle()
 
@@ -308,6 +338,12 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
       return
     }
 
+    val currency = currencyFromCode(currencyCode)
+    if (currency == null) {
+      result.error("INVALID_ARGUMENT", "'$currencyCode' is not a valid ISO 4217 currency code", null)
+      return
+    }
+
     val parameters = call.argument<Map<String, Any>>("parameters")
     val parameterBundle = createBundleFromMap(parameters) ?: Bundle()
 
@@ -320,13 +356,21 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
       link,
       title,
       BigDecimal.valueOf(priceAmount),
-      Currency.getInstance(currencyCode),
+      currency,
       gtin,
       mpn,
       brand,
       parameterBundle
     )
     result.success(null)
+  }
+
+  private fun currencyFromCode(code: String): Currency? {
+    return try {
+      Currency.getInstance(code)
+    } catch (e: IllegalArgumentException) {
+      null
+    }
   }
 
   private fun productAvailabilityFromToken(token: String): AppEventsLogger.ProductAvailability? {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,7 @@ class MyApp extends StatelessWidget {
                       firstName: 'Oddbit',
                       city: 'Denpasar',
                       country: 'Indonesia',
+                      externalId: 'example-user-42',
                     );
                   },
                 ),
@@ -64,15 +65,31 @@ class MyApp extends StatelessWidget {
                   },
                 ),
                 MaterialButton(
-                  child: Text("Enable advertise tracking!"),
+                  child: Text("Enable advertiser ID collection"),
                   onPressed: () {
-                    facebookAppEvents.setAdvertiserTracking(enabled: true);
+                    facebookAppEvents.setAdvertiserIdCollectionEnabled(true);
                   },
                 ),
                 MaterialButton(
-                  child: Text("Disabled advertise tracking!"),
+                  child: Text("Disable advertiser ID collection"),
                   onPressed: () {
-                    facebookAppEvents.setAdvertiserTracking(enabled: false);
+                    facebookAppEvents.setAdvertiserIdCollectionEnabled(false);
+                  },
+                ),
+                MaterialButton(
+                  child: Text("Limit event and data usage"),
+                  onPressed: () {
+                    facebookAppEvents.setLimitEventAndDataUsage(true);
+                  },
+                ),
+                MaterialButton(
+                  child: Text("Enable Limited Data Use (LDU)"),
+                  onPressed: () {
+                    facebookAppEvents.setDataProcessingOptions(
+                      ['LDU'],
+                      country: 0,
+                      state: 0,
+                    );
                   },
                 ),
                 MaterialButton(
@@ -102,7 +119,8 @@ class MyApp extends StatelessWidget {
                 MaterialButton(
                   child: Text("Register push token"),
                   onPressed: () {
-                    facebookAppEvents.setPushNotificationToken('example-token');
+                    facebookAppEvents
+                        .setPushNotificationsDeviceToken('example-token');
                   },
                 ),
                 MaterialButton(

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -26,8 +26,10 @@ void main() {
     expect(find.text('Set user data'), findsOneWidget);
     expect(find.text('Test logAddToCart'), findsOneWidget);
     expect(find.text('Test purchase!'), findsOneWidget);
-    expect(find.text('Enable advertise tracking!'), findsOneWidget);
-    expect(find.text('Disabled advertise tracking!'), findsOneWidget);
+    expect(find.text('Enable advertiser ID collection'), findsOneWidget);
+    expect(find.text('Disable advertiser ID collection'), findsOneWidget);
+    expect(find.text('Limit event and data usage'), findsOneWidget);
+    expect(find.text('Enable Limited Data Use (LDU)'), findsOneWidget);
   });
 
   testWidgets('Button text content', (WidgetTester tester) async {
@@ -42,9 +44,12 @@ void main() {
         findsOneWidget);
     expect(
         find.widgetWithText(MaterialButton, 'Test purchase!'), findsOneWidget);
-    expect(find.widgetWithText(MaterialButton, 'Enable advertise tracking!'),
+    expect(
+        find.widgetWithText(MaterialButton, 'Enable advertiser ID collection'),
         findsOneWidget);
-    expect(find.widgetWithText(MaterialButton, 'Disabled advertise tracking!'),
+    expect(
+        find.widgetWithText(
+            MaterialButton, 'Disable advertiser ID collection'),
         findsOneWidget);
   });
 }

--- a/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
+++ b/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
@@ -260,10 +260,21 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     private func handleSetDataProcessingOptions(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? [String: Any] ?? [:]
         let options = arguments["options"] as? [String] ?? []
-        let country = arguments["country"] as? Int ?? 0
-        let state = arguments["state"] as? Int ?? 0
 
-        Settings.shared.setDataProcessingOptions(options, country: Int32(country), state: Int32(state))
+        // The channel codec delivers Dart ints as Int64 when they exceed
+        // Int32, so a forced Int32(_:) conversion would trap. The native API
+        // takes Int32, so reject out-of-range values instead of crashing.
+        guard let country = Int32(exactly: arguments["country"] as? Int ?? 0),
+              let state = Int32(exactly: arguments["state"] as? Int ?? 0) else {
+            result(FlutterError(
+                code: "INVALID_ARGUMENT",
+                message: "country and state must fit in a 32-bit integer",
+                details: nil
+            ))
+            return
+        }
+
+        Settings.shared.setDataProcessingOptions(options, country: country, state: state)
         result(nil)
     }
 

--- a/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
+++ b/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
@@ -104,11 +104,15 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
             handleGetAnonymousId(call, result: result)
         case "setAdvertiserTracking":
             handleSetAdvertiserTracking(call, result: result)
+        case "setAdvertiserIdCollectionEnabled":
+            handleSetAdvertiserIdCollectionEnabled(call, result: result)
+        case "setLimitEventAndDataUsage":
+            handleSetLimitEventAndDataUsage(call, result: result)
         case "setGraphApiVersion":
             handleSetGraphApiVersion(call, result: result)
         case "logProductItem":
             handleLogProductItem(call, result: result)
-        case "setPushNotificationToken":
+        case "setPushNotificationsDeviceToken", "setPushNotificationToken":
             handleSetPushNotificationToken(call, result: result)
         case "setFlushBehavior":
             handleSetFlushBehavior(call, result: result)
@@ -130,8 +134,14 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     private func handleActivateApp(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? [String: Any] ?? [:]
 
+        // The override applies per call, matching Android's
+        // `activateApp(application, applicationId)` where a null id falls back
+        // to the default app id. `loggingOverrideAppID` is global state on the
+        // SDK, so reset it when no id is given.
         if let applicationId = arguments["applicationId"] as? String, !applicationId.isEmpty {
             AppEvents.shared.loggingOverrideAppID = applicationId
+        } else {
+            AppEvents.shared.loggingOverrideAppID = nil
         }
 
         AppEvents.shared.activateApp()
@@ -146,16 +156,29 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     private func handleSetUserData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments as? [String: Any] ?? [:]
 
-        AppEvents.shared.setUserData(arguments["email"] as? String, forType: FBSDKAppEventUserDataType.email)
-        AppEvents.shared.setUserData(arguments["firstName"] as? String, forType: FBSDKAppEventUserDataType.firstName)
-        AppEvents.shared.setUserData(arguments["lastName"] as? String, forType: FBSDKAppEventUserDataType.lastName)
-        AppEvents.shared.setUserData(arguments["phone"] as? String, forType: FBSDKAppEventUserDataType.phone)
-        AppEvents.shared.setUserData(arguments["dateOfBirth"] as? String, forType: FBSDKAppEventUserDataType.dateOfBirth)
-        AppEvents.shared.setUserData(arguments["gender"] as? String, forType: FBSDKAppEventUserDataType.gender)
-        AppEvents.shared.setUserData(arguments["city"] as? String, forType: FBSDKAppEventUserDataType.city)
-        AppEvents.shared.setUserData(arguments["state"] as? String, forType: FBSDKAppEventUserDataType.state)
-        AppEvents.shared.setUserData(arguments["zip"] as? String, forType: FBSDKAppEventUserDataType.zip)
-        AppEvents.shared.setUserData(arguments["country"] as? String, forType: FBSDKAppEventUserDataType.country)
+        // Merge semantics: only update the fields present in the call.
+        // Passing nil to the native setter REMOVES the stored field on iOS,
+        // while Android ignores nulls (merge), so skipping absent keys here
+        // keeps both platforms consistent. Clearing is done explicitly via
+        // clearUserData / clearUserDataForType.
+        let fields: [(key: String, type: FBSDKAppEventUserDataType)] = [
+            ("email", .email),
+            ("firstName", .firstName),
+            ("lastName", .lastName),
+            ("phone", .phone),
+            ("dateOfBirth", .dateOfBirth),
+            ("gender", .gender),
+            ("city", .city),
+            ("state", .state),
+            ("zip", .zip),
+            ("country", .country),
+            ("externalId", .externalId),
+        ]
+        for field in fields {
+            if let value = arguments[field.key] as? String {
+                AppEvents.shared.setUserData(value, forType: field.type)
+            }
+        }
 
         result(nil)
     }
@@ -171,10 +194,10 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     }
 
     private func handleGetApplicationId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        // Facebook SDK 18.x+: appID property was removed from Settings
-        // Retrieve from Info.plist FacebookAppID key as fallback
-        let appId = Bundle.main.object(forInfoDictionaryKey: "FacebookAppID") as? String
-        result(appId)
+        // Settings.shared.appID resolves the Info.plist FacebookAppID by
+        // default and reflects any app id set programmatically on the SDK,
+        // matching Android's `appEventsLogger.applicationId`.
+        result(Settings.shared.appID)
     }
 
     private func handleGetAnonymousId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -235,10 +258,12 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     }
 
     private func handleSetDataProcessingOptions(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        // Facebook SDK 18.x+: setDataProcessingOptions was removed from Settings
-        // Data processing options should now be configured via Facebook's Data Use Checkup
-        // See: https://developers.facebook.com/docs/development/data-processing-options
-        print("[FacebookAppEvents] setDataProcessingOptions() is not available in Facebook SDK 18.x+. Configure data processing options via Facebook's Data Use Checkup.")
+        let arguments = call.arguments as? [String: Any] ?? [:]
+        let options = arguments["options"] as? [String] ?? []
+        let country = arguments["country"] as? Int ?? 0
+        let state = arguments["state"] as? Int ?? 0
+
+        Settings.shared.setDataProcessingOptions(options, country: Int32(country), state: Int32(state))
         result(nil)
     }
 
@@ -278,6 +303,18 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
         Settings.shared.isAdvertiserTrackingEnabled = enabled
         Settings.shared.isAdvertiserIDCollectionEnabled = enabled && collectId
 
+        result(nil)
+    }
+
+    private func handleSetAdvertiserIdCollectionEnabled(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let enabled = call.arguments as? Bool ?? false
+        Settings.shared.isAdvertiserIDCollectionEnabled = enabled
+        result(nil)
+    }
+
+    private func handleSetLimitEventAndDataUsage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let enabled = call.arguments as? Bool ?? false
+        Settings.shared.isEventDataUsageLimited = enabled
         result(nil)
     }
 
@@ -410,6 +447,7 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
         case "state": return .state
         case "zip": return .zip
         case "country": return .country
+        case "externalId": return .externalId
         default: return nil
         }
     }

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -104,7 +104,9 @@ class FacebookAppEvents {
   /// If you provide an [applicationId], the native SDK will be configured to
   /// log to that App ID instead of the default app id from platform config.
   /// (On iOS this uses `loggingOverrideAppID`; on Android it is passed to
-  /// `activateApp(Application, applicationId)`.)
+  /// `activateApp(Application, applicationId)`.) The override applies per
+  /// call: calling [activateApp] again without an [applicationId] reverts to
+  /// the default app id on both platforms.
   ///
   /// See documentation:
   /// - [iOS](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/fbsdkappevents.html)
@@ -131,6 +133,14 @@ class FacebookAppEvents {
   /// instance of an application. The user data will be persisted between
   /// application instances.
   ///
+  /// Merge semantics: only the fields you pass are updated; fields that are
+  /// `null` (or omitted) keep their previously-set value on both platforms.
+  /// To remove fields use [clearUserData] (all fields) or
+  /// [clearUserDataForType] (single field, iOS only).
+  ///
+  /// [externalId] is your own identifier for the user, used by Meta for
+  /// advanced matching (`extern_id`).
+  ///
   /// See documentation:
   /// - [iOS](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/fbsdkappevents.html)
   /// - [Android](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/appevents/appeventslogger.html)
@@ -145,6 +155,7 @@ class FacebookAppEvents {
     String? state,
     String? zip,
     String? country,
+    String? externalId,
   }) {
     final args = <String, dynamic>{
       'email': email,
@@ -157,6 +168,7 @@ class FacebookAppEvents {
       'state': state,
       'zip': zip,
       'country': country,
+      'externalId': externalId,
     };
 
     return _channel.invokeMethod<void>('setUserData', _filterOutNulls(args));
@@ -182,7 +194,10 @@ class FacebookAppEvents {
 
   /// Returns the app ID this logger was configured to log to.
   ///
-  /// Note: on iOS, this plugin reads `FacebookAppID` from `Info.plist`.
+  /// Maps to `appEventsLogger.applicationId` on Android and
+  /// `Settings.shared.appID` on iOS — both resolve the app id from platform
+  /// configuration (`AndroidManifest.xml` / `Info.plist`) and reflect any app
+  /// id set programmatically on the SDK.
   ///
   /// See documentation:
   /// - [iOS](https://developers.facebook.com/docs/ios/getting-started)
@@ -202,9 +217,14 @@ class FacebookAppEvents {
 
   /// Log an app event with the specified [name] and the supplied [parameters] value.
   ///
-  /// - [parameters] should contain only JSON-compatible values. On Android
-  ///   these values are converted into a `Bundle`, so supported types are
-  ///   limited to primitives (String/num/bool) and nested maps of the same.
+  /// The native SDKs only accept `String` and numeric parameter values; an
+  /// event containing any other value type is silently dropped by the SDK.
+  /// This method therefore accepts `String`, `num`, and `bool` values —
+  /// booleans are converted to `"1"`/`"0"` (Meta's yes/no convention, see
+  /// [paramValueYes]/[paramValueNo]) so the event is recorded identically on
+  /// both platforms. Any other value type (lists, maps, ...) throws an
+  /// [ArgumentError]; encode structured values as a JSON string first (as
+  /// Meta prescribes for [paramNameContent]).
   ///
   /// See documentation:
   /// - [iOS](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/fbsdkappevents.html)
@@ -220,7 +240,7 @@ class FacebookAppEvents {
     };
 
     if (parameters != null) {
-      args['parameters'] = _filterOutNulls(parameters);
+      args['parameters'] = _normalizeParameters(parameters);
     }
 
     return _channel.invokeMethod<void>('logEvent', _filterOutNulls(args));
@@ -392,15 +412,19 @@ class FacebookAppEvents {
     return _channel.invokeMethod<void>('setAutoLogAppEventsEnabled', enabled);
   }
 
-  /// Sets data processing options (CCPA / limited data use).
+  /// Sets data processing options (CCPA / Limited Data Use).
   ///
-  /// Platform behavior:
-  /// - Android: calls the native `FacebookSdk.setDataProcessingOptions(...)`.
-  /// - iOS: the upstream iOS SDK removed this API in recent versions; this
-  ///   method currently performs no action on iOS.
+  /// Maps to `FacebookSdk.setDataProcessingOptions(options, country, state)`
+  /// on Android and `Settings.shared.setDataProcessingOptions(options,
+  /// country:state:)` on iOS.
+  ///
+  /// For example, to enable Limited Data Use with geolocation:
+  /// `setDataProcessingOptions(['LDU'], country: 0, state: 0)`. Passing an
+  /// empty [options] list disables Limited Data Use.
   ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/development/data-processing-options
+  /// - [iOS Settings](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/settings.html)
   /// - [Android FacebookSdk](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/FacebookSdk.html)
   Future<void> setDataProcessingOptions(
     List<String> options, {
@@ -420,6 +444,10 @@ class FacebookAppEvents {
   ///
   /// [currency] should be an ISO 4217 currency code (for example: `"USD"`).
   ///
+  /// [parameters] follows the same value-type rules as [logEvent]: `String`,
+  /// `num`, and `bool` (sent as `"1"`/`"0"`); other types throw an
+  /// [ArgumentError].
+  ///
   /// See documentation:
   /// - [iOS](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/fbsdkappevents.html)
   /// - [Android](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/appevents/appeventslogger.html)
@@ -431,7 +459,7 @@ class FacebookAppEvents {
     final args = <String, dynamic>{
       'amount': amount,
       'currency': currency,
-      'parameters': parameters,
+      if (parameters != null) 'parameters': _normalizeParameters(parameters),
     };
     return _channel.invokeMethod<void>('logPurchase', _filterOutNulls(args));
   }
@@ -470,16 +498,23 @@ class FacebookAppEvents {
 
   /// Sets advertiser tracking / advertiser ID collection flags.
   ///
-  /// This typically needs to be aligned with your user consent flow and the
-  /// platform's privacy requirements.
+  /// Deprecated because the two flags it couples no longer exist as a pair on
+  /// either platform:
   ///
-  /// Note: this method no longer toggles verbose SDK debug logging as a side
-  /// effect on Android. Use [setDebugLoggingEnabled] to control SDK logging
-  /// explicitly on both platforms.
+  /// - On iOS, `Settings.isAdvertiserTrackingEnabled` is deprecated since
+  ///   Facebook SDK v17: the SDK derives tracking consent from
+  ///   `ATTrackingManager.trackingAuthorizationStatus` and ignores this setter
+  ///   on iOS 17+. Request App Tracking Transparency authorization in your
+  ///   app instead.
+  /// - On Android, no tracking-enabled flag exists; only advertiser ID
+  ///   collection is configurable, and this method reduces to
+  ///   `setAdvertiserIDCollectionEnabled(enabled && collectId)`.
   ///
-  /// See documentation:
-  /// - [iOS Settings](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/settings.html)
-  /// - [Android FacebookSdk](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/FacebookSdk.html)
+  /// Use [setAdvertiserIdCollectionEnabled] instead, which maps 1:1 to the
+  /// native setting on both platforms.
+  @Deprecated('Use setAdvertiserIdCollectionEnabled instead. On iOS the SDK '
+      'derives tracking consent from App Tracking Transparency, and on '
+      'Android only advertiser ID collection is configurable.')
   Future<void> setAdvertiserTracking({
     required bool enabled,
     bool collectId = true,
@@ -490,6 +525,40 @@ class FacebookAppEvents {
     };
 
     return _channel.invokeMethod<void>('setAdvertiserTracking', args);
+  }
+
+  /// Enables/disables collection of the device advertiser ID (IDFA on iOS,
+  /// Google Advertising ID on Android) with logged events.
+  ///
+  /// Maps to `Settings.shared.isAdvertiserIDCollectionEnabled` (iOS) and
+  /// `FacebookSdk.setAdvertiserIDCollectionEnabled` (Android). Align this
+  /// with your user consent flow.
+  ///
+  /// Note that on iOS the advertiser ID is only available when the user has
+  /// granted App Tracking Transparency authorization.
+  ///
+  /// See documentation:
+  /// - [iOS Settings](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/settings.html)
+  /// - [Android FacebookSdk](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/FacebookSdk.html)
+  Future<void> setAdvertiserIdCollectionEnabled(bool enabled) {
+    return _channel.invokeMethod<void>(
+      'setAdvertiserIdCollectionEnabled',
+      enabled,
+    );
+  }
+
+  /// Restricts logged event data from being used for purposes other than
+  /// analytics and conversions (e.g. targeting ads to the user).
+  ///
+  /// Maps to `FacebookSdk.setLimitEventAndDataUsage` (Android) and
+  /// `Settings.shared.isEventDataUsageLimited` (iOS). The setting is
+  /// persisted across app launches. Defaults to `false`.
+  ///
+  /// See documentation:
+  /// - [iOS Settings](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/settings.html)
+  /// - [Android FacebookSdk](https://developers.facebook.com/docs/reference/androidsdk/current/facebook/com/facebook/FacebookSdk.html)
+  Future<void> setLimitEventAndDataUsage(bool enabled) {
+    return _channel.invokeMethod<void>('setLimitEventAndDataUsage', enabled);
   }
 
   /// The start of a paid subscription for a product or service you offer.
@@ -662,7 +731,7 @@ class FacebookAppEvents {
       'gtin': gtin,
       'mpn': mpn,
       'brand': brand,
-      'parameters': parameters,
+      if (parameters != null) 'parameters': _normalizeParameters(parameters),
     };
 
     return _channel.invokeMethod<void>(
@@ -671,8 +740,8 @@ class FacebookAppEvents {
     );
   }
 
-  /// Registers a push notification [token] with the SDK so Meta can attribute
-  /// push-driven app opens and measure push campaigns.
+  /// Registers a push notification device [token] with the SDK so Meta can
+  /// attribute push-driven app opens and measure push campaigns.
   ///
   /// Platform mapping:
   /// - iOS: `AppEvents.setPushNotificationsDeviceToken(_:)` (the String overload).
@@ -680,8 +749,18 @@ class FacebookAppEvents {
   ///   selector is renamed to `setPushNotificationsDeviceToken(_:)` in Swift via
   ///   `NS_SWIFT_NAME`, so that is the symbol this plugin calls.
   /// - Android: `AppEventsLogger.setPushNotificationsRegistrationId`.
+  Future<void> setPushNotificationsDeviceToken(String token) {
+    return _channel.invokeMethod<void>(
+      'setPushNotificationsDeviceToken',
+      token,
+    );
+  }
+
+  /// Registers a push notification [token] with the SDK.
+  @Deprecated('Use setPushNotificationsDeviceToken instead, which follows the '
+      'native SDK naming.')
   Future<void> setPushNotificationToken(String token) {
-    return _channel.invokeMethod<void>('setPushNotificationToken', token);
+    return setPushNotificationsDeviceToken(token);
   }
 
   /// Sets the [FlushBehavior] controlling when events are sent to Meta.
@@ -723,8 +802,8 @@ class FacebookAppEvents {
   /// network requests).
   ///
   /// This replaces the implicit debug-logging side effect that previously lived
-  /// in [setAdvertiserTracking] on Android; call this explicitly when you want
-  /// SDK logs during development.
+  /// in the deprecated `setAdvertiserTracking` on Android; call this explicitly
+  /// when you want SDK logs during development.
   Future<void> setDebugLoggingEnabled(bool enabled) {
     return _channel.invokeMethod<void>('setDebugLoggingEnabled', enabled);
   }
@@ -744,5 +823,30 @@ class FacebookAppEvents {
       }
     });
     return filtered;
+  }
+
+  /// Normalizes event [parameters] to the value types accepted by the native
+  /// SDKs: drops `null` entries, keeps `String`/`num` values, converts `bool`
+  /// to `"1"`/`"0"`, and throws [ArgumentError] for anything else — the native
+  /// SDKs silently drop the whole event when given an unsupported value type.
+  Map<String, dynamic> _normalizeParameters(Map<String, dynamic> parameters) {
+    final Map<String, dynamic> normalized = <String, dynamic>{};
+    parameters.forEach((String key, dynamic value) {
+      if (value == null) {
+        return;
+      } else if (value is bool) {
+        normalized[key] = value ? paramValueYes : paramValueNo;
+      } else if (value is String || value is num) {
+        normalized[key] = value;
+      } else {
+        throw ArgumentError.value(
+          value,
+          key,
+          'App event parameter values must be String, num, or bool. '
+          'Encode structured values as a JSON string (json.encode) first.',
+        );
+      }
+    });
+    return normalized;
   }
 }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -80,6 +80,10 @@ enum FacebookUserDataField {
   state,
   zip,
   country,
+
+  /// Your own identifier for the user (`extern_id`), used by Meta for
+  /// advanced matching.
+  externalId,
 }
 
 /// Parses a [FlushBehavior] from a wire token, defaulting to

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -189,6 +189,68 @@ void main() {
       );
     });
 
+    test('logEvent converts bool parameters to "1"/"0"', () async {
+      await facebookAppEvents.logEvent(
+        name: 'test-event',
+        parameters: <String, dynamic>{'success': true, 'retried': false},
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'test-event',
+            'parameters': <String, dynamic>{
+              'success': '1',
+              'retried': '0',
+            },
+          },
+        ),
+      );
+    });
+
+    test('logEvent drops null parameter values', () async {
+      await facebookAppEvents.logEvent(
+        name: 'test-event',
+        parameters: <String, dynamic>{'a': 'b', 'empty': null},
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: <String, dynamic>{
+            'name': 'test-event',
+            'parameters': <String, dynamic>{'a': 'b'},
+          },
+        ),
+      );
+    });
+
+    test('logEvent throws ArgumentError for nested map parameters', () async {
+      expect(
+        () => facebookAppEvents.logEvent(
+          name: 'test-event',
+          parameters: <String, dynamic>{
+            'nested': {'id': '1'},
+          },
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('logEvent throws ArgumentError for list parameters', () async {
+      expect(
+        () => facebookAppEvents.logEvent(
+          name: 'test-event',
+          parameters: <String, dynamic>{
+            'items': ['a', 'b'],
+          },
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('Purchase logging', () {
@@ -229,6 +291,40 @@ void main() {
         ),
       );
     });
+
+    test('logPurchase converts bool parameters to "1"/"0"', () async {
+      await facebookAppEvents.logPurchase(
+        amount: 12.34,
+        currency: 'USD',
+        parameters: <String, dynamic>{'first_purchase': true},
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logPurchase',
+          arguments: <String, dynamic>{
+            'amount': 12.34,
+            'currency': 'USD',
+            'parameters': <String, dynamic>{'first_purchase': '1'},
+          },
+        ),
+      );
+    });
+
+    test('logPurchase throws ArgumentError for nested map parameters',
+        () async {
+      expect(
+        () => facebookAppEvents.logPurchase(
+          amount: 12.34,
+          currency: 'USD',
+          parameters: <String, dynamic>{
+            'content': {'id': '1'},
+          },
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('User data', () {
@@ -245,6 +341,24 @@ void main() {
           'setUserData',
           arguments: <String, dynamic>{
             'email': 'user@example.com',
+          },
+        ),
+      );
+    });
+
+    test('setUserData forwards externalId', () async {
+      await facebookAppEvents.setUserData(
+        email: 'user@example.com',
+        externalId: 'crm-42',
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'setUserData',
+          arguments: <String, dynamic>{
+            'email': 'user@example.com',
+            'externalId': 'crm-42',
           },
         ),
       );
@@ -332,6 +446,7 @@ void main() {
     });
 
     test('setAdvertiserTracking forwards enabled and collectId', () async {
+      // ignore: deprecated_member_use_from_same_package
       await facebookAppEvents.setAdvertiserTracking(
         enabled: true,
         collectId: false,
@@ -346,6 +461,24 @@ void main() {
             'collectId': false,
           },
         ),
+      );
+    });
+
+    test('setAdvertiserIdCollectionEnabled forwards boolean', () async {
+      await facebookAppEvents.setAdvertiserIdCollectionEnabled(true);
+
+      expect(
+        methodCall,
+        isMethodCall('setAdvertiserIdCollectionEnabled', arguments: true),
+      );
+    });
+
+    test('setLimitEventAndDataUsage forwards boolean', () async {
+      await facebookAppEvents.setLimitEventAndDataUsage(true);
+
+      expect(
+        methodCall,
+        isMethodCall('setLimitEventAndDataUsage', arguments: true),
       );
     });
 
@@ -652,14 +785,33 @@ void main() {
         isMethodCall('clearUserDataForType', arguments: 'email'),
       );
     });
+
+    test('clearUserDataForType forwards externalId token', () async {
+      await facebookAppEvents
+          .clearUserDataForType(FacebookUserDataField.externalId);
+      expect(
+        methodCall,
+        isMethodCall('clearUserDataForType', arguments: 'externalId'),
+      );
+    });
   });
 
   group('Push token and debug logging', () {
-    test('setPushNotificationToken forwards token as scalar', () async {
+    test('setPushNotificationsDeviceToken forwards token as scalar', () async {
+      await facebookAppEvents.setPushNotificationsDeviceToken('tok-123');
+      expect(
+        methodCall,
+        isMethodCall('setPushNotificationsDeviceToken', arguments: 'tok-123'),
+      );
+    });
+
+    test('deprecated setPushNotificationToken delegates to the new method',
+        () async {
+      // ignore: deprecated_member_use_from_same_package
       await facebookAppEvents.setPushNotificationToken('tok-123');
       expect(
         methodCall,
-        isMethodCall('setPushNotificationToken', arguments: 'tok-123'),
+        isMethodCall('setPushNotificationsDeviceToken', arguments: 'tok-123'),
       );
     });
 


### PR DESCRIPTION
## Summary

A deep review of the plugin against the actual Facebook SDK sources (iOS 18.0.0–18.0.3, Android `sdk-version-18.1.3`) found two iOS handlers built on incorrect \"removed in 18.x\" claims, three silent cross-platform behavior divergences, and a few missing parity APIs. This PR fixes all of them.

## Fixes

### Incorrect \"removed API\" claims (iOS)
- **`setDataProcessingOptions` is now functional on iOS.** `Settings.shared.setDataProcessingOptions(_:country:state:)` is public and functional in every 18.x release — it was never removed (verified in SDK source; the confusion likely came from the API moving from a class method to an instance method on `Settings.shared`). The \"no-op on iOS\" known limitation is removed from README/CLAUDE.md/dartdoc.
- **`getApplicationId` now returns `Settings.shared.appID`** instead of reading `Info.plist` directly. The property was never removed either, and the SDK value also reflects programmatic app-id configuration, matching Android.

### Silent cross-platform divergences
- **`setUserData` now merges on both platforms.** The iOS handler passed `nil` for absent fields, which *clears* them in `FBSDKUserDataStore`, while Android ignores nulls. The iOS handler now only sets fields present in the call; clearing stays explicit via `clearUserData`/`clearUserDataForType`.
- **Event parameters are validated in the Dart layer.** The native SDKs accept only String/numeric values and **silently drop the entire event** otherwise (verified in `FBSDKAppEvents.m` validation and Android's `AppEvent.validateParameters`). Booleans — previously recorded on iOS but dropped on Android — are now converted to `\"1\"`/`\"0\"` on both platforms; lists/maps throw `ArgumentError` with a hint to JSON-encode.
- **`activateApp(applicationId:)` override is per-call on iOS** — `loggingOverrideAppID` is reset when no id is passed, matching Android's fallback to the default app id.

### Parity additions
- `externalId` on `setUserData` + `FacebookUserDataField` (Meta advanced matching `extern_id`; 11-arg overload on Android, `FBSDKAppEventExternalId` on iOS).
- `setLimitEventAndDataUsage(bool)` → `FacebookSdk.setLimitEventAndDataUsage` / `Settings.shared.isEventDataUsageLimited`.
- `setAdvertiserIdCollectionEnabled(bool)`; **deprecates `setAdvertiserTracking`** (the iOS tracking flag is deprecated since FBSDK v17 and ATT-derived on iOS 17+; Android only has ID collection).
- `setPushNotificationsDeviceToken(String)` (native SDK naming); **deprecates `setPushNotificationToken`**, which delegates to it.

### Smaller fixes
- Android `logPurchase`/`logProductItem` return `INVALID_ARGUMENT` for invalid ISO 4217 currency codes instead of an opaque platform exception.
- Android `setUserData` reads fields directly from the call arguments instead of roundtripping through a `Bundle`.
- README: documented event-parameter value rules and the plugin's API scope (intentionally unexposed native APIs).

## Testing

- `flutter test`: 62 plugin tests pass (incl. new coverage for bool conversion, `ArgumentError` on nested values, `externalId`, the new methods, and the deprecated alias delegation).
- `flutter test` (example): passes.
- `flutter analyze`: clean apart from the two pre-existing example infos on `main`.
- Android/iOS native compilation could not be run locally (no Android SDK/Xcode on this machine); Android compiles via the PR-acceptance APK build. All native calls were written against signatures verified directly in the SDK sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)