### PR TITLE
chore: plumbing upgrade 2026-07-02

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -108,9 +108,9 @@ jobs:
           # AGP 9.1.1 requires Gradle >= 9.3.1 and enables Built-in Kotlin by default, so the
           # example app must no longer apply kotlin-android (Flutter supplies KGP). Migrating it
           # here lets this cell exercise the plugin's `agpMajor >= 9` branch end to end.
-          sed -i 's#com.android.tools.build:gradle:8.9.2#com.android.tools.build:gradle:9.1.1#' example/android/build.gradle
-          sed -i 's#com.android.application" version "8.9.2"#com.android.application" version "9.1.1"#' example/android/settings.gradle
-          sed -i 's#gradle-8.11.1-bin.zip#gradle-9.3.1-bin.zip#' example/android/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's#com.android.tools.build:gradle:8.13.0#com.android.tools.build:gradle:9.1.1#' example/android/build.gradle
+          sed -i 's#com.android.application" version "8.13.0"#com.android.application" version "9.1.1"#' example/android/settings.gradle
+          sed -i 's#gradle-8.13-bin.zip#gradle-9.3.1-bin.zip#' example/android/gradle/wrapper/gradle-wrapper.properties
           sed -i '/id "kotlin-android"/d' example/android/app/build.gradle
           sed -i '/kotlinOptions {/,/}/d' example/android/app/build.gradle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.30.2
+
+- **Update Android toolchain** — AGP 8.13.0, Gradle 8.13, Kotlin 2.4.0, `compileSdk`/`targetSdk` 36. No change to `minSdk` or the Facebook Android SDK Maven range (`[18.0,19.0)`), which already resolves to the latest 18.x release (18.3.0); the CocoaPods/SPM `~> 18.0` / `"18.0.0"..<"19.0.0"` iOS pins likewise already cover the latest 18.x release (18.1.0), so no iOS dependency changes were needed this round.
+
 ## 0.30.1
 
 - **Fix (Android):** stop triggering Flutter 3.44+'s "plugins that apply Kotlin Gradle Plugin (KGP)" warning and build on AGP 9, without raising the minimum Flutter SDK. KGP is now applied only on AGP < 9 (Flutter's Built-in Kotlin supplies it otherwise) (fixes [#492](https://github.com/oddbit/flutter_facebook_app_events/issues/492)).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.9.2")
+        classpath("com.android.tools.build:gradle:8.13.0")
     }
 }
 
@@ -39,7 +39,7 @@ if (agpMajor < 9) {
 android {
     namespace "id.oddbit.flutter.facebook_app_events"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -56,7 +56,7 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 36
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-# AGP 8.9.x pairs with Gradle 8.11.1
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+# AGP 8.13.x pairs with Gradle 8.13
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "2.3.10"
+    ext.kotlin_version = "2.4.0"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
-#Fri Oct 17 00:00:00 UTC 2025
+#Thu Jul 02 00:00:00 UTC 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 
-# AGP 8.9.x pairs with Gradle 8.11.1
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+# AGP 8.13.x pairs with Gradle 8.13
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.3.10" apply false
+    id "com.android.application" version "8.13.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'facebook_app_events'
-  s.version          = '0.30.1'
+  s.version          = '0.30.2'
   s.summary          = 'Flutter plugin for Facebook Analytics and App Events'
   s.description      = <<-DESC
 Flutter plugin for Facebook Analytics and App Events

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.30.1
+version: 0.30.2
 homepage: https://oddb.it/app-events-pubspec
 repository: https://github.com/oddbit/flutter_facebook_app_events
 


### PR DESCRIPTION
This PR was generated by the scheduled automated plumbing-upgrade job.

## SDK bumps

| SDK | Old | New | Pin/constraint used |
|---|---|---|---|
| Facebook Android SDK (`com.facebook.android:facebook-android-sdk`) | resolves to 18.2.x | resolves to 18.3.0 (latest) | unchanged: `[18.0,19.0)` (major-only range already covers it) |
| Facebook iOS SDK (`FBSDKCoreKit`) | resolves to 18.0.x | resolves to 18.1.0 (latest) | unchanged: `~> 18.0` (podspec) / `"18.0.0"..<"19.0.0"` (SPM) — already covers it |
| `FBAudienceNetwork` | n/a | n/a | not a dependency in this repo (previously dropped); verified absent from the podspec, no action taken |

No Facebook SDK major version has shipped, so the existing major-only pins already resolve to the latest 18.x patch/minor releases on both platforms — no pin edits were needed, and no native source changes were forced (checked both SDKs' CHANGELOGs for the versions in range; no breaking API changes, deployment-target bumps, or Swift/Kotlin version requirement changes).

## Build tooling bumps

| Component | Old | New |
|---|---|---|
| Android Gradle Plugin (plugin + example) | 8.9.2 | 8.13.0 |
| Gradle wrapper (plugin + example) | 8.11.1 | 8.13 |
| Kotlin (example) | 2.3.10 | 2.4.0 |
| Android `compileSdk` (plugin) | 35 | 36 |
| Android `targetSdk` (plugin) | 35 | 36 |
| Android `minSdk` | 21 | 21 (unchanged) |
| iOS deployment target | 13.0 | 13.0 (unchanged — not required by 18.1.0) |
| Swift tools-version (SPM manifest) | 5.9 | 5.9 (unchanged — not required by 18.1.0) |
| Flutter / Dart SDK constraint | `flutter: '>=3.38.0'`, `sdk: '>=3.3.0 <4.0.0'` | unchanged — no toolchain change here requires raising the floor |

AGP was bumped within the 8.x line (8.9.2 → 8.13.0, the last release before AGP moved to the 9.x series) rather than jumping to AGP 9.x. The maintainers' own CI (`build-verify.yml`) already treats AGP 9 as an experimental, allowed-to-fail matrix cell pending a Built-in-Kotlin migration of the example app — bumping the default toolchain to AGP 9 in this automated run would go against that explicit, deliberate decision, so it was left alone as the "next" stable line.

## Files touched

- `.github/workflows/build-verify.yml` — updated the experimental AGP-9 CI cell's `sed` patches so they still match the new 8.13.0/8.13 baseline (they previously targeted the old 8.9.2/8.11.1 strings and would have silently no-op'd against the new baseline)
- `CHANGELOG.md` — new `0.30.2` entry
- `android/build.gradle` — AGP, `compileSdk`, `targetSdk`
- `android/gradle/wrapper/gradle-wrapper.properties` — Gradle wrapper + comment
- `example/android/build.gradle` — AGP, Kotlin
- `example/android/gradle/wrapper/gradle-wrapper.properties` — Gradle wrapper + comment + timestamp
- `example/android/settings.gradle` — AGP, Kotlin
- `ios/facebook_app_events.podspec` — version bump only (kept in sync with `pubspec.yaml` per `CONTRIBUTING.md`)
- `pubspec.yaml` — version bump

## Source code changes forced by the SDK bump

None. Checked the Facebook Android SDK CHANGELOG (18.0.0–18.3.0) and Facebook iOS SDK CHANGELOG (18.0.0–18.1.0) for the versions the floating pins now resolve to — no breaking API changes, deprecations affecting this plugin, deployment-target bumps, or Swift/Kotlin requirement changes.

## Verification

- Ruby syntax check (`ruby -c`) on `ios/facebook_app_events.podspec` and `example/ios/Podfile` — passed
- YAML parse check (`python3 -c "import yaml..."`) on `pubspec.yaml` and `example/pubspec.yaml` — passed
- Manual review of `test/android_build_gradle_test.dart` — confirmed it asserts on structural regex patterns (KGP DSL-application detection), not literal version strings, so it is unaffected by these bumps
- Full grep sweep across the repo for the old version strings (`8.9.2`, `8.11.1`, `2.3.10`, `compileSdk 35`, `targetSdk 35`) post-edit — the only remaining matches are historical `CHANGELOG.md` entries for past releases (correctly left as-is)

## Verification skipped

This sandbox has no Flutter SDK, Dart SDK, Android SDK, or CocoaPods toolchain installed (`flutter`, `dart`, `pod` all unavailable; no `ANDROID_HOME`). As a result the following could not be run and need to be confirmed by CI on this PR:
- `flutter pub get` (root and example)
- `flutter analyze` (example)
- `flutter test` (root and example)
- Android `assembleDebug` build of the example
- Refreshing `example/ios/Podfile.lock` via `pod install`

## Plugin version

Old: `0.30.1` → New: `0.30.2`

New CHANGELOG entry, verbatim:

> ## 0.30.2
>
> - **Update Android toolchain** — AGP 8.13.0, Gradle 8.13, Kotlin 2.4.0, `compileSdk`/`targetSdk` 36. No change to `minSdk` or the Facebook Android SDK Maven range (`[18.0,19.0)`), which already resolves to the latest 18.x release (18.3.0); the CocoaPods/SPM `~> 18.0` / `"18.0.0"..<"19.0.0"` iOS pins likewise already cover the latest 18.x release (18.1.0), so no iOS dependency changes were needed this round.

## Reviewer notes

- The public Dart API is unchanged — no edits were made to `lib/*.dart`.
- The iOS CocoaPods spec (`~> 18.0`) and the SPM manifest (`"18.0.0"..<"19.0.0"`) remain in lockstep — neither needed to change this round.
- Deferred: bumping the default Android toolchain to AGP 9.x. The maintainers' own CI already marks AGP 9 as an experimental, allowed-to-fail matrix cell (see `build-verify.yml`) pending a full migration of the example app off `kotlin-android`/`kotlinOptions` to Built-in Kotlin. This automated run intentionally stayed on the 8.x line (now at its final release, 8.13.0) rather than force that migration.
- CI on this PR will exercise the real `flutter build apk`/`flutter build ios` paths that could not be run in the sandbox — please confirm green before merging.

---

*Generated automatically by the scheduled plumbing-upgrade job. Closing this PR is safe — the next scheduled run will start fresh from `main`.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPj1bfZSbrW5aAibHaZBsu)_