### PR TITLE
fix: codebase review — Android getApplicationId staleness, clean push-payload errors, 32-bit guard (v0.30.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.30.3
+
+- **Fix (Android):** `getApplicationId` now reads the live `FacebookSdk.getApplicationId()` instead of the app id captured when the plugin attached to the engine, so app-id changes made programmatically after startup are reflected — matching iOS (`Settings.shared.appID`) and the documented behavior.
+- **Fix (Android):** `logPushNotificationOpen` now returns a clean `INVALID_ARGUMENT` error when the payload contains a value an Android `Bundle` cannot represent (e.g. a list), instead of an opaque platform exception. The error message names the offending key and suggests JSON-encoding structured values.
+- **Fix:** `setDataProcessingOptions` validates in the Dart layer that `country` and `state` fit in a signed 32-bit integer (the type the native APIs take) and throws a `RangeError` otherwise. Out-of-range values previously surfaced as an opaque `ClassCastException` on Android; iOS already rejected them natively.
+- Stop sending explicit `null`s over the method channel for omitted arguments of `setDataProcessingOptions` and `logPushNotificationOpen`, consistent with the rest of the API.
+
 ## 0.30.2
 
 - **Update Android toolchain** — AGP 8.13.0, Gradle 8.13, Kotlin 2.4.0, `compileSdk`/`targetSdk` 36. No change to `minSdk` or the Facebook Android SDK Maven range (`[18.0,19.0)`), which already resolves to the latest 18.x release (18.3.0); the CocoaPods/SPM `~> 18.0` / `"18.0.0"..<"19.0.0"` iOS pins likewise already cover the latest 18.x release (18.1.0), so no iOS dependency changes were needed this round.

--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -157,7 +157,6 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
     result.success(anonymousId)
   }
 
-
   private fun handleSetGraphApiVersion(call: MethodCall, result: Result) {
     val version = call.arguments as? String
     if (version == null) {

--- a/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
+++ b/android/src/main/kotlin/id/oddbit/flutter/facebook_app_events/FacebookAppEventsPlugin.kt
@@ -146,12 +146,18 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
   }
 
   private fun handleGetApplicationId(call: MethodCall, result: Result) {
-    result.success(appEventsLogger.applicationId)
+    // Read the live SDK setting rather than `appEventsLogger.applicationId`,
+    // which is captured when the logger is created at engine attach and would
+    // go stale if the app id is changed programmatically afterwards. This
+    // matches the iOS handler, which reads `Settings.shared.appID`.
+    result.success(FacebookSdk.getApplicationId())
   }
- private fun handleGetAnonymousId(call: MethodCall, result: Result) {
+
+  private fun handleGetAnonymousId(call: MethodCall, result: Result) {
     result.success(anonymousId)
   }
-  
+
+
   private fun handleSetGraphApiVersion(call: MethodCall, result: Result) {
     val version = call.arguments as? String
     if (version == null) {
@@ -215,7 +221,15 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
   private fun handlePushNotificationOpen(call: MethodCall, result: Result) {
     val action = call.argument<String>("action")
     val payload = call.argument<Map<String, Any>>("payload")
-    val payloadBundle = createBundleFromMap(payload)
+    // Unlike logEvent parameters, the payload is not validated in the Dart
+    // layer, so map Bundle-incompatible values (e.g. lists) to a clean error
+    // instead of an opaque platform exception.
+    val payloadBundle = try {
+      createBundleFromMap(payload)
+    } catch (e: IllegalArgumentException) {
+      result.error("INVALID_ARGUMENT", e.message, null)
+      return
+    }
     if (payloadBundle == null) {
       result.error("INVALID_ARGUMENT", "Payload is required", null)
       return
@@ -266,7 +280,8 @@ class FacebookAppEventsPlugin: FlutterPlugin, MethodCallHandler {
           }
         }
         else -> throw IllegalArgumentException(
-            "Unsupported value type: ${value::class}")
+            "Unsupported value type ${value.javaClass.simpleName} for key '$key'; " +
+            "encode structured values as a JSON string.")
       }
     }
     return bundle

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   static final facebookAppEvents = FacebookAppEvents();
   @override
   Widget build(BuildContext context) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,12 +42,12 @@ packages:
     source: hosted
     version: "1.19.1"
   facebook_app_events:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.30.0"
+    version: "0.30.3"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,12 +10,12 @@ dependencies:
   flutter:
     sdk: flutter
 
+  facebook_app_events:
+    path: ../
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  facebook_app_events:
-    path: ../
 
 flutter:
   uses-material-design: true

--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'facebook_app_events'
-  s.version          = '0.30.2'
+  s.version          = '0.30.3'
   s.summary          = 'Flutter plugin for Facebook Analytics and App Events'
   s.description      = <<-DESC
 Flutter plugin for Facebook Analytics and App Events

--- a/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
+++ b/ios/facebook_app_events/Sources/facebook_app_events/FacebookAppEventsPlugin.swift
@@ -196,7 +196,7 @@ public class FacebookAppEventsPlugin: NSObject, FlutterPlugin, FlutterSceneLifeC
     private func handleGetApplicationId(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         // Settings.shared.appID resolves the Info.plist FacebookAppID by
         // default and reflects any app id set programmatically on the SDK,
-        // matching Android's `appEventsLogger.applicationId`.
+        // matching Android's `FacebookSdk.getApplicationId()`.
         result(Settings.shared.appID)
     }
 

--- a/lib/facebook_app_events.dart
+++ b/lib/facebook_app_events.dart
@@ -194,7 +194,7 @@ class FacebookAppEvents {
 
   /// Returns the app ID this logger was configured to log to.
   ///
-  /// Maps to `appEventsLogger.applicationId` on Android and
+  /// Maps to `FacebookSdk.getApplicationId()` on Android and
   /// `Settings.shared.appID` on iOS — both resolve the app id from platform
   /// configuration (`AndroidManifest.xml` / `Info.plist`) and reflect any app
   /// id set programmatically on the SDK.
@@ -260,7 +260,10 @@ class FacebookAppEvents {
       'action': action,
     };
 
-    return _channel.invokeMethod<void>('logPushNotificationOpen', args);
+    return _channel.invokeMethod<void>(
+      'logPushNotificationOpen',
+      _filterOutNulls(args),
+    );
   }
 
   /// Sets a user [id] to associate with all app events.
@@ -422,6 +425,9 @@ class FacebookAppEvents {
   /// `setDataProcessingOptions(['LDU'], country: 0, state: 0)`. Passing an
   /// empty [options] list disables Limited Data Use.
   ///
+  /// [country] and [state] must fit in a signed 32-bit integer (the type the
+  /// native APIs take); a [RangeError] is thrown otherwise.
+  ///
   /// See documentation:
   /// - https://developers.facebook.com/docs/development/data-processing-options
   /// - [iOS Settings](https://developers.facebook.com/docs/reference/iossdk/current/FBSDKCoreKit/classes/settings.html)
@@ -431,13 +437,19 @@ class FacebookAppEvents {
     int? country,
     int? state,
   }) {
+    _checkFitsIn32Bits(country, 'country');
+    _checkFitsIn32Bits(state, 'state');
+
     final args = <String, dynamic>{
       'options': options,
       'country': country,
       'state': state,
     };
 
-    return _channel.invokeMethod<void>('setDataProcessingOptions', args);
+    return _channel.invokeMethod<void>(
+      'setDataProcessingOptions',
+      _filterOutNulls(args),
+    );
   }
 
   /// Logs a purchase event.
@@ -812,6 +824,18 @@ class FacebookAppEvents {
   // ---------------------------------------------------------------------------
   //
   // PRIVATE METHODS BELOW HERE
+
+  /// Throws a [RangeError] if [value] does not fit in a signed 32-bit integer.
+  ///
+  /// The standard method codec delivers larger Dart ints as 64-bit values,
+  /// which the native handlers cannot pass to SDK APIs typed as 32-bit ints.
+  static void _checkFitsIn32Bits(int? value, String name) {
+    const min = -0x80000000;
+    const max = 0x7FFFFFFF;
+    if (value != null && (value < min || value > max)) {
+      throw RangeError.range(value, min, max, name);
+    }
+  }
 
   /// Creates a new map containing all of the key/value pairs from [parameters]
   /// except those whose value is `null`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facebook_app_events
 description: Flutter plugin for Facebook App Events, an app measurement
   solution that provides insight on app usage and user engagement in Facebook Analytics.
-version: 0.30.2
+version: 0.30.3
 homepage: https://oddb.it/app-events-pubspec
 repository: https://github.com/oddbit/flutter_facebook_app_events
 

--- a/test/facebook_app_events_test.dart
+++ b/test/facebook_app_events_test.dart
@@ -501,6 +501,38 @@ void main() {
         ),
       );
     });
+
+    test('setDataProcessingOptions omits null country and state', () async {
+      await facebookAppEvents.setDataProcessingOptions(['LDU']);
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'setDataProcessingOptions',
+          arguments: <String, dynamic>{
+            'options': ['LDU'],
+          },
+        ),
+      );
+    });
+
+    test('setDataProcessingOptions throws RangeError for values that do not '
+        'fit in 32 bits', () {
+      expect(
+        () => facebookAppEvents.setDataProcessingOptions(
+          ['LDU'],
+          country: 0x80000000,
+        ),
+        throwsRangeError,
+      );
+      expect(
+        () => facebookAppEvents.setDataProcessingOptions(
+          ['LDU'],
+          state: -0x80000001,
+        ),
+        throwsRangeError,
+      );
+    });
   });
 
   group('User lifecycle', () {
@@ -555,6 +587,22 @@ void main() {
           arguments: <String, dynamic>{
             'payload': {'campaign': 'spring-sale'},
             'action': 'opened',
+          },
+        ),
+      );
+    });
+
+    test('logPushNotificationOpen omits action when null', () async {
+      await facebookAppEvents.logPushNotificationOpen(
+        payload: {'campaign': 'spring-sale'},
+      );
+
+      expect(
+        methodCall,
+        isMethodCall(
+          'logPushNotificationOpen',
+          arguments: <String, dynamic>{
+            'payload': {'campaign': 'spring-sale'},
           },
         ),
       );


### PR DESCRIPTION
Full-codebase review of the Dart API, Android handler, iOS handler, build configs, tests, and docs. The three layers are in very good shape overall; this PR fixes the handful of genuine parity/robustness issues found, bundled as `0.30.3` (rebased on top of the `0.30.2` toolchain bump from #494).

## Fixes

### Android: `getApplicationId` returned a stale app id
The handler read `appEventsLogger.applicationId`, which is captured when the logger is created in `onAttachedToEngine` — so app-id changes made programmatically after startup (or an access-token app id) were never reflected, contradicting the dartdoc and diverging from iOS (`Settings.shared.appID`, which is read live). It now reads the live `FacebookSdk.getApplicationId()`.

### Android: opaque error for Bundle-incompatible push payloads
`logPushNotificationOpen` payloads are (deliberately) not validated in the Dart layer, but `createBundleFromMap` throws `IllegalArgumentException` for values a `Bundle` can't hold (e.g. lists), which surfaced as a generic `PlatformException(error, ...)` with a stack trace — while iOS accepts the same payload. The handler now catches this and returns a clean `INVALID_ARGUMENT`, and the exception message names the offending key and suggests JSON-encoding structured values.

### Dart: `setDataProcessingOptions` 32-bit validation
The standard method codec delivers Dart ints larger than 32 bits as `Long`, so an out-of-range `country`/`state` caused a `ClassCastException` in the Android handler (`call.argument<Int>`). The iOS handler already guards this natively (`Int32(exactly:)`). Per this repo's convention of validating in the Dart layer, `setDataProcessingOptions` now throws a `RangeError` for values that don't fit in a signed 32-bit integer.

## Consistency cleanups

- `setDataProcessingOptions` and `logPushNotificationOpen` no longer send explicit `null`s over the channel for omitted arguments — every other multi-argument method already filters them via `_filterOutNulls`.
- Example app: `facebook_app_events` moved from `dev_dependencies` to `dependencies` (it's imported by `lib/main.dart` — this was an analyzer `depend_on_referenced_packages` info), and `MyApp` got a `const` constructor with a `key` parameter. `flutter analyze` is now clean with zero infos.

## Release prep (per CONTRIBUTING.md)

- `pubspec.yaml` and `ios/facebook_app_events.podspec` bumped together to `0.30.3`.
- `CHANGELOG.md` entry added above the `0.30.2` entry from #494.

## Verification

- `flutter analyze`: no issues.
- `flutter test` (root): 66/66 passing (re-run after the rebase), including new tests for the `RangeError` guard and the omitted-null wire shapes of `setDataProcessingOptions` / `logPushNotificationOpen`.
- `flutter test` (example): passing.
- Kotlin changes are exercised by the existing Android build matrix in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqZG34ExQKtZX5QHkD2UFL